### PR TITLE
feat(controller): roll pods on auth.existingSecret changes

### DIFF
--- a/internal/controller/reconciler_test.go
+++ b/internal/controller/reconciler_test.go
@@ -589,3 +589,55 @@ func TestReconcileClusterReshardOnAnnotation(t *testing.T) {
 		t.Fatalf("reshard job not created on annotation: %v", err)
 	}
 }
+
+func TestMapSecretToCluster(t *testing.T) {
+	scheme := newTestScheme(t)
+	const ns = "ns"
+	mkVC := func(name string, auth *cachev1beta1.AuthSpec, tls *cachev1beta1.TLSSpec) *cachev1beta1.ValkeyCluster {
+		return &cachev1beta1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       cachev1beta1.ValkeyClusterSpec{Auth: auth, TLS: tls},
+		}
+	}
+	authExt := func() *cachev1beta1.AuthSpec {
+		return &cachev1beta1.AuthSpec{Enabled: true, ExistingSecret: "shared-auth"}
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		mkVC("c1", authExt(), nil),                                                       // references shared-auth
+		mkVC("c2", authExt(), nil),                                                       // also references shared-auth
+		mkVC("c3", &cachev1beta1.AuthSpec{Enabled: true}, nil),                           // generated secret, no existingSecret
+		mkVC("c4", nil, &cachev1beta1.TLSSpec{Enabled: true, ExistingSecret: "tls-ext"}), // TLS existingSecret
+	).Build()
+	r := &ValkeyClusterReconciler{Client: c, Scheme: scheme}
+
+	names := func(reqs []ctrl.Request) []string {
+		out := make([]string, 0, len(reqs))
+		for _, req := range reqs {
+			out = append(out, req.Name)
+		}
+		slices.Sort(out)
+		return out
+	}
+	mapped := func(secretName string) []string {
+		s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns}}
+		return names(r.mapSecretToCluster(context.Background(), s))
+	}
+
+	// A user-managed auth.existingSecret update enqueues every cluster referencing it.
+	if got := mapped("shared-auth"); !slices.Equal(got, []string{"c1", "c2"}) {
+		t.Errorf("auth existingSecret shared-auth → %v, want [c1 c2]", got)
+	}
+	// The TLS cert Secret still enqueues its cluster (no regression).
+	if got := mapped("tls-ext"); !slices.Equal(got, []string{"c4"}) {
+		t.Errorf("tls existingSecret tls-ext → %v, want [c4]", got)
+	}
+	// An unreferenced Secret enqueues nothing.
+	if got := mapped("unrelated"); len(got) != 0 {
+		t.Errorf("unreferenced secret → %v, want none", got)
+	}
+	// The operator-managed generated auth Secret for c3 is "c3-auth"; it must NOT be
+	// enqueued through this path — Owns() already covers operator-owned Secrets.
+	if got := mapped("c3-auth"); len(got) != 0 {
+		t.Errorf("generated auth secret c3-auth → %v, want none (handled by Owns)", got)
+	}
+}

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -747,29 +747,38 @@ func (r *ValkeyClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// slow: the pod can be recreated faster than that, and the survivors then
 		// resync from the empty primary (data loss — see cha-02/cha-03 chaos).
 		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(mapPodToCluster)).
-		// Watch the TLS cert Secret. cert-manager renews it in place (owned by the
-		// Certificate, not the ValkeyCluster, so Owns() misses it); a renewal must
-		// enqueue a reconcile so the operator reloads the cert onto live pods
-		// without a restart.
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.mapTLSSecretToCluster)).
+		// Watch user-managed Secrets the operator does not own: the TLS cert Secret
+		// (cert-manager renews it in place, owned by the Certificate, so Owns()
+		// misses it — a renewal reloads the cert onto live pods without a restart)
+		// and an auth.existingSecret (an external password rotation must re-render
+		// the config and roll the pods). Operator-managed Secrets are owned by the
+		// ValkeyCluster and already covered by Owns() above.
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.mapSecretToCluster)).
 		Named("valkeycluster").
 		Complete(r)
 }
 
-// mapTLSSecretToCluster routes a Secret event to any ValkeyCluster in the same
-// namespace that uses it as its TLS cert Secret. The cert Secret carries no
-// operator labels (cert-manager owns it), so we match by the resolved TLS secret
-// name; the per-namespace list is cheap under the one-cluster-per-namespace DBaaS
-// layout.
-func (r *ValkeyClusterReconciler) mapTLSSecretToCluster(ctx context.Context, obj client.Object) []reconcile.Request {
+// mapSecretToCluster routes a Secret event to any ValkeyCluster in the same
+// namespace that references it as a user-managed Secret the operator does not
+// own: either the TLS cert Secret (cert-manager owns it) or an
+// auth.existingSecret (the user owns it). These carry no operator owner ref, so
+// Owns() misses them; we match by the resolved name instead. The operator's own
+// generated Secrets ARE owned and covered by Owns(); they use a different name
+// than any existingSecret, so the name match here naturally skips them. The
+// per-namespace list is cheap under the one-cluster-per-namespace layout.
+func (r *ValkeyClusterReconciler) mapSecretToCluster(ctx context.Context, obj client.Object) []reconcile.Request {
 	var list cachev1beta1.ValkeyClusterList
 	if err := r.List(ctx, &list, client.InNamespace(obj.GetNamespace())); err != nil {
 		return nil
 	}
+	name := obj.GetName()
 	var reqs []reconcile.Request
 	for i := range list.Items {
 		vc := &list.Items[i]
-		if tlsEnabled(vc) && tlsSecretName(vc) == obj.GetName() {
+		tlsMatch := tlsEnabled(vc) && tlsSecretName(vc) == name
+		authMatch := vc.Spec.Auth != nil && vc.Spec.Auth.Enabled &&
+			vc.Spec.Auth.ExistingSecret != "" && vc.Spec.Auth.ExistingSecret == name
+		if tlsMatch || authMatch {
 			reqs = append(reqs, reconcile.Request{
 				NamespacedName: types.NamespacedName{Namespace: vc.Namespace, Name: vc.Name},
 			})


### PR DESCRIPTION
Closes #10.

## Problem
`spec.auth.existingSecret` (a user-managed Secret) had no watch, so updating it after an external password rotation did not enqueue the referencing `ValkeyCluster`. The generated `valkey.conf` ConfigMap and the StatefulSet's config-hash stayed stale, and pods kept the previous credential until some unrelated reconcile happened.

## Fix
Extend the existing Secret watch mapper (`mapTLSSecretToCluster` → `mapSecretToCluster`) to also enqueue any cluster whose enabled `auth.existingSecret` matches the changed Secret, mirroring the TLS cert-Secret path. On reconcile the operator re-reads the Secret, re-renders the ConfigMap with the new password (which is embedded in `valkey.conf`), the config hash changes, and the StatefulSet rolls. Operator-managed Secrets stay covered by `Owns()`; their generated name differs from any `existingSecret`, so the name match here skips them.

## Validation
- New unit test `TestMapSecretToCluster`: an `auth.existingSecret` shared by two clusters enqueues both; the TLS secret still enqueues (no regression); an unreferenced Secret enqueues nothing; an operator-owned generated auth Secret is not matched via this path.
- `go build`, `go vet`, `make lint` (0 issues) pass locally.

Thanks @attilaolah for the precise issue and the implementation sketch.