### PR TITLE
fix(auth): re-seed users.acl when the auth password changes

### DIFF
--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -590,25 +590,40 @@ func renderInitScript(vc *cachev1beta1.ValkeyCluster) string {
 	// NO key glob — so it cannot read or write your data, unlike the default
 	// user. (S1 hardening; tightening to the minimal per-command set is a
 	// follow-up that needs e2e failover validation.)
-	sentinelACL := ""
+	sentinelSeed, sentinelReseed := "", ""
 	if vc.Spec.Topology == cachev1beta1.TopologySentinel {
-		sentinelACL = fmt.Sprintf("    echo \"user %s on #$PW_HASH &* +@all\" >> %s/users.acl\n",
+		sentinelSeed = fmt.Sprintf("    echo \"user %s on #$PW_HASH &* +@all\" >> %s/users.acl\n",
+			sentinelACLUser, dataMountPath)
+		sentinelReseed = fmt.Sprintf("    echo \"user %s on #$PW_HASH &* +@all\" >> %s/users.acl.new\n",
 			sentinelACLUser, dataMountPath)
 	}
+	// users.acl seeding. Valkey applies `requirepass` first, then loads the
+	// aclfile, and the aclfile is authoritative — so the operator-managed users
+	// (default, plus the Sentinel user) carry the password as a SHA-256 hash here.
+	// When the password changes (e.g. a rotated auth.existingSecret, which
+	// re-renders requirepass and rolls the pods) the seeded hash no longer matches,
+	// so we rewrite ONLY the operator-managed user lines and preserve any other
+	// users an `ACL SAVE` persisted (the ValkeyACL CRD). The init runs locally in
+	// the pod, so no live authentication (and thus no knowledge of the old
+	// password) is needed.
 	common := fmt.Sprintf(`set -eu
 cp %[1]s/valkey.conf %[2]s/runtime.conf
-if [ ! -s %[2]s/users.acl ]; then
-  if [ -n "${VALKEY_PASSWORD:-}" ]; then
-    PW_HASH=$(printf '%%s' "$VALKEY_PASSWORD" | sha256sum | awk '{print $1}')
+if [ -n "${VALKEY_PASSWORD:-}" ]; then
+  PW_HASH=$(printf '%%s' "$VALKEY_PASSWORD" | sha256sum | awk '{print $1}')
+  if [ ! -s %[2]s/users.acl ]; then
     echo "user default on #$PW_HASH ~* &* +@all" > %[2]s/users.acl
-%[3]s  else
-    : > %[2]s/users.acl
+%[3]s  elif ! grep -q "^user default on #$PW_HASH " %[2]s/users.acl; then
+    grep -vE "^user (default|%[5]s) " %[2]s/users.acl > %[2]s/users.acl.new || true
+    echo "user default on #$PW_HASH ~* &* +@all" >> %[2]s/users.acl.new
+%[4]s    mv %[2]s/users.acl.new %[2]s/users.acl
   fi
+elif [ ! -s %[2]s/users.acl ]; then
+  : > %[2]s/users.acl
 fi
 valkey_config_arg() {
   awk 'BEGIN { printf "\"" } { if (NR > 1) printf "\\n"; gsub(/\\/, "\\\\"); gsub(/"/, "\\\""); printf "%%s", $0 } END { printf "\"\n" }'
 }
-	`, configMountPath, dataMountPath, sentinelACL)
+	`, configMountPath, dataMountPath, sentinelSeed, sentinelReseed, sentinelACLUser)
 
 	// Multi-region: every pod (including pod-0) replicates from an external
 	// primary. Local primary/replica entrypoint logic is bypassed.

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -5,6 +5,9 @@ Copyright 2026 The Wellcake Authors.
 package controller
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1398,5 +1401,52 @@ func TestPodAndContainerSecurityContextRestrictedDefaults(t *testing.T) {
 		if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
 			t.Errorf("%s: user containerSecurityContext not honored", c.Name)
 		}
+	}
+}
+
+func TestRenderInitScriptReseedsDefaultUserOnPasswordChange(t *testing.T) {
+	std := minimalCR()
+	std.Spec.Auth = &cachev1beta1.AuthSpec{Enabled: true}
+	s := renderInitScript(std)
+	for _, want := range []string{
+		`grep -q "^user default on #$PW_HASH "`,     // re-seed unless the line already carries the new hash
+		`grep -vE "^user (default|sentinel-user) "`, // preserve other ACL users while replacing operator-managed ones
+		dataMountPath + "/users.acl.new",            // rewrite via a temp file
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("init script missing re-seed-on-change logic %q\n%s", want, s)
+		}
+	}
+	// Sentinel must re-seed its dedicated ACL user too; it also carries the password.
+	sen := renderInitScript(sentinelCR())
+	if !strings.Contains(sen, `echo "user sentinel-user on #$PW_HASH &* +@all" >> `+dataMountPath+"/users.acl.new") {
+		t.Errorf("sentinel init must re-seed the sentinel ACL user on a password change\n%s", sen)
+	}
+}
+
+func TestRenderInitScriptIsValidShell(t *testing.T) {
+	std := minimalCR()
+	std.Spec.Auth = &cachev1beta1.AuthSpec{Enabled: true}
+	cl := minimalCR()
+	cl.Spec.Topology = cachev1beta1.TopologyCluster
+	cl.Spec.Shards = ptr.To[int32](3)
+	mr := minimalCR()
+	mr.Spec.ReplicateFrom = &cachev1beta1.ReplicateFromSpec{Host: "src", Port: 6379}
+	cases := map[string]*cachev1beta1.ValkeyCluster{
+		"standalone":  std,
+		"sentinel":    sentinelCR(),
+		"cluster":     cl,
+		"multiregion": mr,
+	}
+	for name, vc := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := filepath.Join(t.TempDir(), "init.sh")
+			if err := os.WriteFile(f, []byte(renderInitScript(vc)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if out, err := exec.Command("sh", "-n", f).CombinedOutput(); err != nil {
+				t.Fatalf("generated init script is not valid shell: %v\n%s", err, out)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #13. Follow-up to #10 / #8.

## Problem
#10 made the operator reconcile (and roll the pods) when a user-managed `auth.existingSecret` changes. But the roll alone does not rotate the effective auth, as @attilaolah found in #8 ("I had to wipe the broken `users.acl` files even after changing the password"):

- config-init seeds `users.acl` only when the file is **empty** (to preserve `ACL SAVE` state);
- Valkey applies `requirepass` first, then loads the aclfile, and the **aclfile is authoritative**;
- so a rolled pod re-renders `requirepass` with the new password, but the existing `user default ... #oldhash` line wins. The new password never takes effect until the file is wiped.

## Why not a live ACL rotation
The issue (#13) suggested driving the same live `ACL SETUSER` the `rotate-password` annotation uses. That isn't possible for an **external** secret change: once the user overwrites the Secret, the operator only has the *new* password and cannot authenticate to the running pods (still on the *old* one) to rotate them live.

## Fix
config-init re-seeds the **operator-managed** ACL users (`default`, plus the Sentinel `sentinel-user`) when the seeded hash no longer matches the current `VALKEY_PASSWORD`, and **preserves** any other users an `ACL SAVE` persisted (the ValkeyACL CRD). It runs locally in the pod, so no old password / live auth is needed. Combined with the roll #10 already triggers (new `requirepass` → config-hash change → StatefulSet roll), the new credential takes effect with no manual `users.acl` wipe.

## Validation
- `sh -n` syntax check of the generated init script across standalone / replication / sentinel / cluster / multi-region (`TestRenderInitScriptIsValidShell`).
- `TestRenderInitScriptReseedsDefaultUserOnPasswordChange`: the re-seed-on-change logic is present and the Sentinel user is re-seeded too.
- Existing init-script tests still pass; `go build`, `go vet`, `make lint` (0 issues) clean.
- The kind e2e exercises the init script against a real Valkey.

Thanks @attilaolah for catching the `users.acl` stickiness.