### PR TITLE
feat(controller): restricted securityContext on backup/restore Jobs

### DIFF
--- a/internal/controller/backup.go
+++ b/internal/controller/backup.go
@@ -263,6 +263,9 @@ echo "ok"
 			},
 		},
 		{Name: envAWSDefaultRegion, Value: s3.Region},
+		// aws-cli writes its CLI cache under $HOME; running non-root under the
+		// restricted PSA, the default HOME may be unwritable, so point it at tmpfs.
+		{Name: "HOME", Value: "/tmp"},
 	}
 	if s3.Endpoint != "" {
 		awsEnv = append(awsEnv, corev1.EnvVar{Name: envS3EndpointURL, Value: s3.Endpoint})
@@ -296,11 +299,12 @@ echo "ok"
 						Spec: corev1.PodSpec{
 							RestartPolicy: corev1.RestartPolicyOnFailure,
 							InitContainers: []corev1.Container{{
-								Name:         "dump",
-								Image:        dumpImage,
-								Command:      []string{shellCmd, "-c", dumpScript},
-								Env:          env,
-								VolumeMounts: mounts,
+								Name:            "dump",
+								Image:           dumpImage,
+								Command:         []string{shellCmd, "-c", dumpScript},
+								Env:             env,
+								VolumeMounts:    mounts,
+								SecurityContext: containerSecurityContext(vc),
 							}},
 							Containers: []corev1.Container{{
 								Name:    "upload",
@@ -310,8 +314,10 @@ echo "ok"
 								VolumeMounts: []corev1.VolumeMount{
 									{Name: backupVolumeName, MountPath: "/backup"},
 								},
+								SecurityContext: containerSecurityContext(vc),
 							}},
-							Volumes: volumes,
+							Volumes:         volumes,
+							SecurityContext: podSecurityContext(vc),
 						},
 					},
 				},

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -177,8 +177,9 @@ func tlsSecretName(vc *cachev1beta1.ValkeyCluster) string {
 
 // configHashFromData returns a deterministic short hash of a ConfigMap.Data map,
 // used to roll the StatefulSet pods whenever valkey.conf or entrypoint.sh changes.
-// The auth password is intentionally NOT included — it lives in a Secret and is
-// loaded at process start via env/mount; rotating it is handled separately.
+// The rendered valkey.conf carries requirepass, so the auth password DOES affect
+// this hash: a rotated existingSecret re-renders the config and rolls the pods
+// (the auth.existingSecret watch + the init-script ACL re-seed apply the change).
 func configHashFromData(data map[string]string) string {
 	keys := make([]string, 0, len(data))
 	for k := range data {

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -1479,3 +1479,53 @@ func TestClusterJobsHaveRestrictedSecurityContext(t *testing.T) {
 		})
 	}
 }
+
+func TestBackupAndRestoreJobsHaveRestrictedSecurityContext(t *testing.T) {
+	bvc := minimalCR()
+	bvc.Spec.Backup = &cachev1beta1.BackupSpec{
+		Enabled:  true,
+		Schedule: "0 0 * * *",
+		S3:       &cachev1beta1.S3Spec{Bucket: "b", Region: "r", CredentialsSecret: "creds"},
+	}
+	backupPod := buildBackupCronJob(bvc, "b").Spec.JobTemplate.Spec.Template.Spec
+
+	shards := int32(3)
+	rvc := minimalCR()
+	rvc.Spec.Topology = cachev1beta1.TopologyCluster
+	rvc.Spec.Shards = &shards
+	rvc.Spec.RestoreFrom = &cachev1beta1.RestoreSpec{
+		SourceKey: "base-stamp-shard-{shard}.rdb",
+		S3:        &cachev1beta1.S3Spec{Bucket: "bkt", Region: "r", CredentialsSecret: "c"},
+	}
+	restorePod := buildRestoreAssemblyJob(rvc, "pw", "r").Spec.Template.Spec
+
+	for name, spec := range map[string]corev1.PodSpec{"backup": backupPod, "restore": restorePod} {
+		t.Run(name, func(t *testing.T) {
+			if spec.SecurityContext == nil || spec.SecurityContext.RunAsNonRoot == nil || !*spec.SecurityContext.RunAsNonRoot {
+				t.Errorf("%s pod must have a restricted pod securityContext", name)
+			}
+			for _, c := range spec.InitContainers {
+				assertContainerRestricted(t, name+"/init/"+c.Name, c.SecurityContext)
+			}
+			for _, c := range spec.Containers {
+				assertContainerRestricted(t, name+"/"+c.Name, c.SecurityContext)
+			}
+		})
+	}
+
+	// The aws-cli containers run non-root, so they need a writable HOME.
+	hasHome := func(c corev1.Container) bool {
+		for _, e := range c.Env {
+			if e.Name == "HOME" && e.Value == "/tmp" {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasHome(backupPod.Containers[0]) {
+		t.Error("backup aws-cli (upload) container must set HOME=/tmp for non-root")
+	}
+	if !hasHome(restorePod.InitContainers[0]) {
+		t.Error("restore aws-cli (fetch-manifest) container must set HOME=/tmp for non-root")
+	}
+}

--- a/internal/controller/restore_assembly.go
+++ b/internal/controller/restore_assembly.go
@@ -252,6 +252,9 @@ echo "manifest:"; cat /work/manifest.txt
 		{Name: envAWSAccessKey, ValueFrom: secretRef(rs.S3.CredentialsSecret, envAWSAccessKey)},
 		{Name: envAWSSecretKey, ValueFrom: secretRef(rs.S3.CredentialsSecret, envAWSSecretKey)},
 		{Name: envAWSDefaultRegion, Value: rs.S3.Region},
+		// aws-cli writes its CLI cache under $HOME; running non-root under the
+		// restricted PSA, the default HOME may be unwritable, so point it at tmpfs.
+		{Name: "HOME", Value: "/tmp"},
 	}
 	if rs.S3.Endpoint != "" {
 		awsEnv = append(awsEnv, corev1.EnvVar{Name: envS3EndpointURL, Value: rs.S3.Endpoint})
@@ -281,20 +284,23 @@ echo "manifest:"; cat /work/manifest.txt
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyOnFailure,
 					InitContainers: []corev1.Container{{
-						Name:         "fetch-manifest",
-						Image:        awsImage,
-						Command:      []string{shellCmd, "-c", fetchScript},
-						Env:          awsEnv,
-						VolumeMounts: []corev1.VolumeMount{{Name: workVolumeName, MountPath: "/work"}},
+						Name:            "fetch-manifest",
+						Image:           awsImage,
+						Command:         []string{shellCmd, "-c", fetchScript},
+						Env:             awsEnv,
+						VolumeMounts:    []corev1.VolumeMount{{Name: workVolumeName, MountPath: "/work"}},
+						SecurityContext: containerSecurityContext(vc),
 					}},
 					Containers: []corev1.Container{{
-						Name:         "assemble",
-						Image:        vc.Spec.Image,
-						Command:      []string{shellCmd, "-c", script},
-						Env:          valkeyEnv,
-						VolumeMounts: mounts,
+						Name:            "assemble",
+						Image:           vc.Spec.Image,
+						Command:         []string{shellCmd, "-c", script},
+						Env:             valkeyEnv,
+						VolumeMounts:    mounts,
+						SecurityContext: containerSecurityContext(vc),
 					}},
-					Volumes: volumes,
+					Volumes:         volumes,
+					SecurityContext: podSecurityContext(vc),
 				},
 			},
 		},


### PR DESCRIPTION
Closes #9 (final piece, after #12 and #16).

## Problem
The **backup CronJob** (init `dump` = valkey image, main `upload` = aws-cli) and the **restore-assembly Job** (init `fetch-manifest` = aws-cli, main `assemble` = valkey image) had no `securityContext`, so they were rejected under the **restricted** Pod Security Standard. This was the last operator-created pod not yet covered.

## Fix
Both pods get the restricted pod/container security contexts (user override, else the default), same as the StatefulSet and the cluster Jobs. Because the **aws-cli** image runs as **root** by default, the pod-level `runAsUser: 1000` (from the restricted default) makes every container run non-root, and the aws-cli containers also get **`HOME=/tmp`** — aws-cli writes its CLI cache under `$HOME`, which is otherwise unwritable for a non-root uid.

Drive-by: fixed a stale comment on `configHashFromData` (the password *does* affect the hash via the rendered `requirepass`).

## Validation
- `TestBackupAndRestoreJobsHaveRestrictedSecurityContext`: both pods + every container satisfy restricted, and the aws-cli containers set `HOME=/tmp`.
- `go build`, `go vet`, `make lint` (0 issues) pass.

> ⚠️ Reviewer note: the **aws-cli-as-non-root runtime path** (does `aws s3 cp` actually work as uid 1000 with `HOME=/tmp`?) is exercised by the kind e2e if it runs a backup/restore; the unit tests only assert the rendered SC. Worth a sanity check against a real S3 backup in a restricted namespace before relying on it.