### PR TITLE
v0.2 follow-ups: namespace PSS, durable+Replication gate, Sentinel ACL, leader-election test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims to
 follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- The `valkey-cluster` chart can create the release Namespace and label it with
+  the Pod Security Standards (`namespace.create`, `namespace.podSecurityStandard`),
+  so the restricted-PSA-compatible Valkey pods are actually enforced (S2).
+
+### Changed
+- The validating webhook now **rejects** `profile: Durable` on a `Replication`
+  topology at create time — that combination relies on operator-arbitrated
+  failover, which has a split-brain window on a network partition (AR1/EC1).
+  Acknowledge the risk to proceed by setting the annotation
+  `valkey.wellcake.io/accept-replication-durability-risk: "true"`; for durable
+  data prefer `Sentinel` or `Cluster`. Existing clusters are unaffected on update.
+- The Sentinel ACL user is narrowed from all commands to the minimal Sentinel
+  command set (health/role checks, the `__sentinel__:hello` pub/sub, the failover
+  transaction, `CONFIG REWRITE`, and `CLIENT`/`SCRIPT KILL`); it still carries no
+  key access — least privilege for the user Sentinel authenticates as (S1).
+
 ## [0.2.0]
 
 Hardens auth handling and makes every operator-managed pod compatible with the
@@ -67,6 +86,7 @@ First public release of the operator. Highlights of the initial feature set:
 - CEL XValidation for immutable and conditional fields; config-hash-driven
   rolling restarts; version-gated Valkey 9.x resilience directives.
 
+[Unreleased]: https://github.com/melancholictheory/wellcake/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/melancholictheory/wellcake/releases/tag/v0.2.0
 [0.1.1]: https://github.com/melancholictheory/wellcake/releases/tag/v0.1.1
 [0.1.0]: https://github.com/melancholictheory/wellcake/releases/tag/v0.1.0

--- a/charts/valkey-cluster/templates/namespace.yaml
+++ b/charts/valkey-cluster/templates/namespace.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    {{- include "valkey-cluster.labels" . | nindent 4 }}
+    {{- with .Values.namespace.podSecurityStandard }}
+    pod-security.kubernetes.io/enforce: {{ . }}
+    pod-security.kubernetes.io/warn: {{ . }}
+    pod-security.kubernetes.io/audit: {{ . }}
+    {{- end }}
+    {{- with .Values.namespace.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/valkey-cluster/values.yaml
+++ b/charts/valkey-cluster/values.yaml
@@ -5,6 +5,19 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# Optionally have this chart create the release Namespace and label it with the
+# Pod Security Standards, so the restricted-PSA-compatible Valkey pods are
+# actually enforced. When create=true the chart OWNS the namespace — install
+# WITHOUT `helm --create-namespace`, into a namespace that does not yet exist,
+# otherwise Helm refuses to adopt a namespace it does not manage.
+namespace:
+  create: false
+  # enforce/warn/audit level: restricted | baseline | privileged.
+  # Empty string → create the namespace without Pod Security labels.
+  podSecurityStandard: restricted
+  # Extra labels to merge onto the namespace.
+  labels: {}
+
 # Topology: Standalone | Replication | Sentinel | Cluster
 topology: Replication
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,16 @@ The code has two independent strategies:
 In the `Cluster` topology there is no operator-driven failover — native Valkey
 gossip handles it.
 
+Because the Replication strategy is operator-arbitrated (bounded by the reconcile
+interval and the operator's own liveness, with a split-brain window on a network
+partition), the validating webhook **rejects** a `Durable` profile on a
+`Replication` topology at create time (AR1/EC1). For durable data prefer
+`Sentinel` or `Cluster`, which arbitrate failover in the data plane. To create the
+combination anyway — acknowledging the risk — set the annotation
+`valkey.wellcake.io/accept-replication-durability-risk: "true"`. The gate applies
+only on create: an existing cluster keeps working (with a warning) across an
+operator upgrade.
+
 ## Proactive rolling restart (ADR 0004)
 
 Opt-in via the `valkey.wellcake.io/proactive-rollout: "true"` annotation

--- a/internal/controller/leaderelection_test.go
+++ b/internal/controller/leaderelection_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Wellcake Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// Op1: prove HA handover between leader-elected operator replicas. Two managers
+// contend for the same lease against the envtest API server; the standby must
+// not steal an actively-renewed lease, and must take over promptly once the
+// active leader steps down. This exercises the real coordination.k8s.io Lease
+// path the deployed operator uses (`--leader-elect`), not a mock.
+var _ = Describe("Leader election handover (Op1)", func() {
+	It("promotes a standby manager when the active leader steps down", func() {
+		const leaseID = "op1-handover.wellcake.io"
+		const leaseNS = "default"
+
+		newMgr := func() ctrl.Manager {
+			m, err := ctrl.NewManager(cfg, ctrl.Options{
+				Scheme:                        scheme.Scheme,
+				LeaderElection:                true,
+				LeaderElectionID:              leaseID,
+				LeaderElectionNamespace:       leaseNS,
+				LeaderElectionReleaseOnCancel: true,
+				// Short timings so the test converges in seconds; the invariant
+				// (single holder, clean handover) is independent of the values.
+				LeaseDuration:          ptr.To(6 * time.Second),
+				RenewDeadline:          ptr.To(4 * time.Second),
+				RetryPeriod:            ptr.To(1 * time.Second),
+				Metrics:                metricsserver.Options{BindAddress: "0"},
+				HealthProbeBindAddress: "0",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return m
+		}
+
+		// holder returns the current lease holder identity ("" if none).
+		holder := func() string {
+			var lease coordinationv1.Lease
+			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: leaseNS, Name: leaseID}, &lease); err != nil {
+				return ""
+			}
+			if lease.Spec.HolderIdentity == nil {
+				return ""
+			}
+			return *lease.Spec.HolderIdentity
+		}
+
+		By("starting leader A")
+		mgrA := newMgr()
+		ctxA, cancelA := context.WithCancel(ctx)
+		go func() {
+			defer GinkgoRecover()
+			_ = mgrA.Start(ctxA)
+		}()
+
+		Eventually(holder, 30*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty())
+		leaderA := holder()
+		By("leader A holds the lease: " + leaderA)
+
+		By("starting standby B — it must not steal an actively-renewed lease")
+		mgrB := newMgr()
+		ctxB, cancelB := context.WithCancel(ctx)
+		defer cancelB()
+		go func() {
+			defer GinkgoRecover()
+			_ = mgrB.Start(ctxB)
+		}()
+		Consistently(holder, 5*time.Second, 1*time.Second).Should(Equal(leaderA))
+
+		By("leader A steps down (graceful cancel releases the lease)")
+		cancelA()
+
+		By("standby B takes over with a different, non-empty identity")
+		Eventually(holder, 30*time.Second, 250*time.Millisecond).
+			ShouldNot(Or(BeEmpty(), Equal(leaderA)))
+
+		cancelB()
+	})
+})

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -585,18 +585,16 @@ func renderInitScript(vc *cachev1beta1.ValkeyCluster) string {
 	// default user stays nopass, matching auth-disabled intent. The file must
 	// exist regardless — Valkey refuses to start if aclfile points at nothing.
 	// For Sentinel topology, seed a dedicated least-data-exposure ACL user that
-	// Sentinel uses to reach the master (sentinel auth-user). It gets all
-	// commands and all pub/sub channels (Sentinel needs INFO/REPLICAOF/CONFIG
-	// REWRITE/CLIENT KILL/SCRIPT KILL plus the __sentinel__:hello channel) but
-	// NO key glob — so it cannot read or write your data, unlike the default
-	// user. (S1 hardening; tightening to the minimal per-command set is a
-	// follow-up that needs e2e failover validation.)
+	// Sentinel uses to reach the master (sentinel auth-user). It gets the minimal
+	// per-command set Sentinel needs (sentinelACLCommands) plus all pub/sub
+	// channels (&*, for __sentinel__:hello) but NO key glob — so it cannot read
+	// or write your data, unlike the default user. (S1 hardening.)
 	sentinelSeed, sentinelReseed := "", ""
 	if vc.Spec.Topology == cachev1beta1.TopologySentinel {
-		sentinelSeed = fmt.Sprintf("    echo \"user %s on #$PW_HASH &* +@all\" >> %s/users.acl\n",
-			sentinelACLUser, dataMountPath)
-		sentinelReseed = fmt.Sprintf("    echo \"user %s on #$PW_HASH &* +@all\" >> %s/users.acl.new\n",
-			sentinelACLUser, dataMountPath)
+		sentinelSeed = fmt.Sprintf("    echo \"user %s on #$PW_HASH &* %s\" >> %s/users.acl\n",
+			sentinelACLUser, sentinelACLCommands, dataMountPath)
+		sentinelReseed = fmt.Sprintf("    echo \"user %s on #$PW_HASH &* %s\" >> %s/users.acl.new\n",
+			sentinelACLUser, sentinelACLCommands, dataMountPath)
 	}
 	// users.acl seeding. Valkey applies `requirepass` first, then loads the
 	// aclfile, and the aclfile is authoritative — so the operator-managed users

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -321,21 +321,31 @@ func TestRenderInitScriptSeedsDefaultUserACL(t *testing.T) {
 }
 
 func TestRenderInitScriptSeedsSentinelACLUser(t *testing.T) {
-	// Sentinel topology with auth seeds a dedicated sentinel-user (all commands,
-	// all channels, NO key glob → no data access) that Sentinel uses to reach
-	// the master via `sentinel auth-user`.
+	// Sentinel topology with auth seeds a dedicated sentinel-user with the
+	// minimal per-command set + all channels, NO key glob → no data access, used
+	// to reach the master via `sentinel auth-user`.
 	vc := minimalCR()
 	vc.Spec.Topology = cachev1beta1.TopologySentinel
 	vc.Spec.Sentinel = &cachev1beta1.SentinelSpec{Replicas: 3}
 	vc.Spec.Auth = &cachev1beta1.AuthSpec{Enabled: true}
 	script := renderInitScript(vc)
 
-	if !strings.Contains(script, "user sentinel-user on #$PW_HASH &* +@all") {
-		t.Errorf("Sentinel init script must seed the sentinel ACL user\n%s", script)
+	if !strings.Contains(script, "user sentinel-user on #$PW_HASH &* "+sentinelACLCommands) {
+		t.Errorf("Sentinel init script must seed the sentinel ACL user with the minimal command set\n%s", script)
+	}
+	// The narrowed user must NOT carry +@all (all commands) any more.
+	if strings.Contains(script, "user sentinel-user on #$PW_HASH &* +@all") {
+		t.Errorf("sentinel-user must use the minimal command set, not +@all\n%s", script)
 	}
 	// No key glob (~) for the sentinel user — it must not read/write data.
-	if strings.Contains(script, "user sentinel-user on #$PW_HASH ~* &* +@all") {
+	if strings.Contains(script, "user sentinel-user on #$PW_HASH ~*") {
 		t.Errorf("sentinel-user must not have key access (~*)\n%s", script)
+	}
+	// Spot-check a couple of essential commands are present.
+	for _, cmd := range []string{"+slaveof", "+info", "+subscribe", "+config|rewrite", "+client|kill"} {
+		if !strings.Contains(script, cmd) {
+			t.Errorf("sentinel-user ACL missing required command %q\n%s", cmd, script)
+		}
 	}
 }
 
@@ -1419,7 +1429,7 @@ func TestRenderInitScriptReseedsDefaultUserOnPasswordChange(t *testing.T) {
 	}
 	// Sentinel must re-seed its dedicated ACL user too; it also carries the password.
 	sen := renderInitScript(sentinelCR())
-	if !strings.Contains(sen, `echo "user sentinel-user on #$PW_HASH &* +@all" >> `+dataMountPath+"/users.acl.new") {
+	if !strings.Contains(sen, `echo "user sentinel-user on #$PW_HASH &* `+sentinelACLCommands+`" >> `+dataMountPath+"/users.acl.new") {
 		t.Errorf("sentinel init must re-seed the sentinel ACL user on a password change\n%s", sen)
 	}
 }

--- a/internal/controller/sentinel.go
+++ b/internal/controller/sentinel.go
@@ -30,6 +30,16 @@ const (
 	// renderInitScript) that Sentinel authenticates as when reaching the
 	// monitored master — least data exposure vs the default user.
 	sentinelACLUser = "sentinel-user"
+	// sentinelACLCommands is the minimal command set this user needs to monitor
+	// and fail over the data nodes — the canonical Redis/Valkey Sentinel ACL
+	// recommendation: health/role checks (ping/info/role), the
+	// __sentinel__:hello pub/sub (subscribe/publish, paired with the &* channel
+	// glob), the failover transaction (multi/exec + slaveof a.k.a. REPLICAOF),
+	// config|rewrite to persist the new topology, and client|kill / script|kill
+	// to interrupt clients and a running script mid-failover. No key glob — the
+	// user can never read or write your data.
+	sentinelACLCommands = "+multi +slaveof +ping +exec +subscribe " +
+		"+config|rewrite +role +publish +info +client|setname +client|kill +script|kill"
 )
 
 // reconcileSentinel brings up Replication primitives plus a separate

--- a/internal/webhook/v1beta1/validators_test.go
+++ b/internal/webhook/v1beta1/validators_test.go
@@ -132,18 +132,29 @@ func TestValkeyClusterValidator(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Durable + Replication -> warn (operator-arbitrated failover)",
+			name: "Durable + Replication on create -> rejected (gate, risk not acknowledged)",
 			mutate: func(vc *cachev1beta1.ValkeyCluster) {
 				vc.Spec.Profile = cachev1beta1.ProfileDurable
 				vc.Spec.Topology = cachev1beta1.TopologyReplication
 			},
-			wantWarns: true,
+			wantErr: true,
 		},
 		{
-			name: "Durable + empty topology (defaults to Replication) -> warn",
+			name: "Durable + empty topology (defaults to Replication) on create -> rejected",
 			mutate: func(vc *cachev1beta1.ValkeyCluster) {
 				vc.Spec.Profile = cachev1beta1.ProfileDurable
 				vc.Spec.Topology = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "Durable + Replication with risk acknowledged -> warn, no error",
+			mutate: func(vc *cachev1beta1.ValkeyCluster) {
+				vc.Spec.Profile = cachev1beta1.ProfileDurable
+				vc.Spec.Topology = cachev1beta1.TopologyReplication
+				vc.Annotations = map[string]string{
+					acceptReplicationDurabilityRiskAnnotation: "true",
+				}
 			},
 			wantWarns: true,
 		},
@@ -201,6 +212,27 @@ func TestValkeyClusterValidator(t *testing.T) {
 				t.Fatalf("ValidateCreate warnings = %v, wantWarns = %v", warns, tc.wantWarns)
 			}
 		})
+	}
+}
+
+// On update the durable+Replication gate must not newly reject a cluster that
+// predates it — an operator upgrade must never strand a running deployment. The
+// combination still surfaces the split-brain warning.
+func TestValkeyClusterValidatorUpdateDoesNotGateDurableReplication(t *testing.T) {
+	vc := &cachev1beta1.ValkeyCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "c"},
+		Spec: cachev1beta1.ValkeyClusterSpec{
+			Profile:  cachev1beta1.ProfileDurable,
+			Topology: cachev1beta1.TopologyReplication,
+		},
+	}
+	v := &ValkeyClusterCustomValidator{Client: newFakeClient()}
+	warns, err := v.ValidateUpdate(context.Background(), vc, vc)
+	if err != nil {
+		t.Fatalf("ValidateUpdate err = %v, want nil (update must not gate the durable+Replication risk)", err)
+	}
+	if len(warns) == 0 {
+		t.Fatalf("ValidateUpdate warnings = %v, want a split-brain warning", warns)
 	}
 }
 

--- a/internal/webhook/v1beta1/valkeycluster_webhook.go
+++ b/internal/webhook/v1beta1/valkeycluster_webhook.go
@@ -22,6 +22,11 @@ import (
 
 var valkeyclusterlog = logf.Log.WithName("valkeycluster-resource")
 
+// acceptReplicationDurabilityRiskAnnotation lets a user opt into the
+// otherwise-rejected durable+Replication combination (AR1/EC1) by explicitly
+// acknowledging its split-brain / operator-arbitrated-failover risk.
+const acceptReplicationDurabilityRiskAnnotation = "valkey.wellcake.io/accept-replication-durability-risk"
+
 // SetupValkeyClusterWebhookWithManager registers the webhook for ValkeyCluster
 // in the manager. It captures mgr.GetClient() because the validator's main job
 // is reading referenced Secrets — checks CEL XValidation can't do.
@@ -56,12 +61,12 @@ type ValkeyClusterCustomValidator struct {
 
 func (v *ValkeyClusterCustomValidator) ValidateCreate(ctx context.Context, obj *cachev1beta1.ValkeyCluster) (admission.Warnings, error) {
 	valkeyclusterlog.V(1).Info("validate create", "name", obj.GetName())
-	return v.validate(ctx, obj)
+	return v.validate(ctx, obj, true)
 }
 
 func (v *ValkeyClusterCustomValidator) ValidateUpdate(ctx context.Context, _, newObj *cachev1beta1.ValkeyCluster) (admission.Warnings, error) {
 	valkeyclusterlog.V(1).Info("validate update", "name", newObj.GetName())
-	return v.validate(ctx, newObj)
+	return v.validate(ctx, newObj, false)
 }
 
 func (v *ValkeyClusterCustomValidator) ValidateDelete(_ context.Context, _ *cachev1beta1.ValkeyCluster) (admission.Warnings, error) {
@@ -98,7 +103,7 @@ func referencedSecrets(vc *cachev1beta1.ValkeyCluster) map[string]string {
 // hard errors at admission time — the alternative is a CR that admits but
 // never reconciles because the controller can't read its inputs, which is
 // confusing for users.
-func (v *ValkeyClusterCustomValidator) validate(ctx context.Context, vc *cachev1beta1.ValkeyCluster) (admission.Warnings, error) {
+func (v *ValkeyClusterCustomValidator) validate(ctx context.Context, vc *cachev1beta1.ValkeyCluster, isCreate bool) (admission.Warnings, error) {
 	for name, where := range referencedSecrets(vc) {
 		var s corev1.Secret
 		if err := v.Client.Get(ctx, types.NamespacedName{Namespace: vc.Namespace, Name: name}, &s); err != nil {
@@ -146,14 +151,24 @@ func (v *ValkeyClusterCustomValidator) validate(ctx context.Context, vc *cachev1
 	// (≈15s cadence) and only while the operator is alive, with a split-brain
 	// window on a network partition. For durable data prefer Sentinel (or a
 	// Cluster topology), which arbitrates failover in the data plane. An empty
-	// topology defaults to Replication, so warn for that case too.
+	// topology defaults to Replication, so this covers that case too.
+	//
+	// Hard gate on create: the combination is rejected unless the user
+	// explicitly acknowledges the risk via the annotation. On update the warning
+	// is kept but never newly rejected, so an operator upgrade does not strand a
+	// running cluster that predates the gate.
 	if vc.Spec.Profile == cachev1beta1.ProfileDurable &&
 		(vc.Spec.Topology == "" || vc.Spec.Topology == cachev1beta1.TopologyReplication) {
-		warnings = append(warnings,
-			"profile=Durable with topology=Replication uses operator-arbitrated failover "+
-				"(bounded by the reconcile interval and the operator's own liveness, with a "+
-				"split-brain window on network partition). For durable data prefer "+
-				"topology=Sentinel or Cluster, which arbitrate failover in the data plane.")
+		const risk = "profile=Durable with topology=Replication uses operator-arbitrated " +
+			"failover (bounded by the reconcile interval and the operator's own liveness, with " +
+			"a split-brain window on network partition); for durable data prefer topology=Sentinel " +
+			"or Cluster, which arbitrate failover in the data plane"
+		acknowledged := vc.Annotations[acceptReplicationDurabilityRiskAnnotation] == "true"
+		if isCreate && !acknowledged {
+			return warnings, fmt.Errorf("%s. To create it anyway, acknowledge the risk by setting "+
+				"the annotation %s=\"true\"", risk, acceptReplicationDurabilityRiskAnnotation)
+		}
+		warnings = append(warnings, risk+".")
 	}
 
 	return warnings, nil


### PR DESCRIPTION
Five items from the ROADMAP follow-up backlog, sitting on top of v0.2.0. Each is small and independent; they're grouped here because they came out of one pass over the backlog.

### Namespace Pod Security Standards (S2)

The valkey-cluster chart can now create the release Namespace and label it with the Pod Security Standards (`namespace.create`, `namespace.podSecurityStandard`). v0.2.0 made the pods restricted-compatible; this is the piece that actually turns the policy on. It's off by default. When `create: true` the chart owns the namespace, so install it without `--create-namespace`.

### Durable + Replication gate (AR1/EC1)

The validating webhook now rejects `profile: Durable` on a `Replication` topology at create time. That pairing relies on operator-arbitrated failover, which has a split-brain window on a network partition. To create it anyway, set `valkey.wellcake.io/accept-replication-durability-risk: "true"`; otherwise prefer Sentinel or Cluster. The gate only fires on create. An existing cluster keeps running (with the previous warning) across an operator upgrade, so nothing gets stranded.

### Sentinel ACL least privilege (S1)

The Sentinel ACL user drops from `+@all` to the minimal command set Sentinel actually needs: ping/info/role, the `__sentinel__:hello` pub/sub, the failover transaction (multi/exec + replicaof), `CONFIG REWRITE`, and `CLIENT`/`SCRIPT KILL`. It still has no key access.

### Leader-election handover test (Op1)

An envtest spec runs two managers against a real coordination.k8s.io Lease. The standby does not steal a lease that's still being renewed, and it takes over once the active leader steps down.

### How it was verified

- build, the full envtest + webhook suites, and `make lint` are clean (0 issues).
- S1: ran a real master + replica + 3-sentinel cluster in Docker with the narrowed user and killed the master. The replica was promoted and there was no NOPERM in the sentinel logs.
- Op1: the handover spec passes in envtest.
- rst-01 (no code change): re-ran the Cluster restore-assembly on real Valkey nodes. The sparse-slot RDBs gap-filled to `cluster_state:ok` with all 16384 slots and no key loss.
- #17 (no code change): ran the aws-cli 2.15.0 binary as uid 1000 with dropped caps and `HOME=/tmp` against MinIO. Backup upload and restore download both work, and the round-trip bytes match.

CHANGELOG `[Unreleased]` is updated. No chart version bump, since this is unreleased.
