### PR TITLE
Recover a Cluster from a lost primary majority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Cluster topology now recovers automatically from the loss of a **majority of
+  primaries** — the disaster gossip cannot fix on its own, because voting a
+  replica in needs a master quorum that no longer exists, so the cluster would
+  otherwise sit in `cluster_state:fail` with unserved slots indefinitely. The
+  operator confirms each dead primary is fenced from two independent
+  perspectives (the k8s API view of pod/node liveness AND a direct data-path
+  check), waits out a debounce so it never races a failover gossip could still
+  perform, then issues `CLUSTER FAILOVER TAKEOVER` on the most up-to-date
+  surviving replica of each shard. The re-created primaries rejoin as replicas
+  via their retained PVCs. Automatic for the Cache profile; opt-in for Durable
+  (via `valkey.wellcake.io/quorum-takeover: "true"`, since a forced takeover can
+  drop acknowledged writes). Surfaced through `status.quorumDownSince` and the
+  `failover_total{reason="cluster-takeover"}` metric. See ADR 0006. Validated
+  live on k3d: majority of primaries fenced, cluster recovered to `ok` with 0
+  data loss and the fenced primaries rejoining as replicas.
+
 ### Changed
 - Replicas now authenticate to their primary as a dedicated, least-privilege ACL
   user (`replicator`, granting only `+psync +replconf +ping` and no key access)

--- a/api/v1beta1/valkeycluster_types.go
+++ b/api/v1beta1/valkeycluster_types.go
@@ -584,6 +584,17 @@ type ValkeyClusterStatus struct {
 	// +optional
 	PrimaryDownSince *metav1.Time `json:"primaryDownSince,omitempty"`
 
+	// QuorumDownSince is when the operator first observed the Cluster topology
+	// stuck in cluster_state:fail with a majority of primaries unreachable —
+	// the state gossip cannot self-heal, because authorizing a replica failover
+	// needs a master quorum that no longer exists. It debounces operator-driven
+	// quorum recovery (CLUSTER FAILOVER TAKEOVER): the operator only intervenes
+	// after the cluster has been stuck for the recovery threshold, giving gossip
+	// time to promote replicas on its own where a quorum still exists. Cleared
+	// once the cluster reports cluster_state:ok again.
+	// +optional
+	QuorumDownSince *metav1.Time `json:"quorumDownSince,omitempty"`
+
 	// InternalEndpoint is the in-cluster client endpoint (host:port) of the
 	// client Service, for consumers to connect to. Surfaced here so wrappers
 	// (e.g. a Crossplane Composition) can project it without recomputing names.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -670,6 +670,10 @@ func (in *ValkeyClusterStatus) DeepCopyInto(out *ValkeyClusterStatus) {
 		in, out := &in.PrimaryDownSince, &out.PrimaryDownSince
 		*out = (*in).DeepCopy()
 	}
+	if in.QuorumDownSince != nil {
+		in, out := &in.QuorumDownSince, &out.QuorumDownSince
+		*out = (*in).DeepCopy()
+	}
 	if in.ShardDetails != nil {
 		in, out := &in.ShardDetails, &out.ShardDetails
 		*out = make([]ShardStatus, len(*in))

--- a/charts/valkey-operator/templates/crd/cache.wellcake.io_valkeyclusters.yaml
+++ b/charts/valkey-operator/templates/crd/cache.wellcake.io_valkeyclusters.yaml
@@ -5089,6 +5089,18 @@ spec:
                   prematurely failed over. Cleared once a master is reachable again.
                 format: date-time
                 type: string
+              quorumDownSince:
+                description: |-
+                  QuorumDownSince is when the operator first observed the Cluster topology
+                  stuck in cluster_state:fail with a majority of primaries unreachable —
+                  the state gossip cannot self-heal, because authorizing a replica failover
+                  needs a master quorum that no longer exists. It debounces operator-driven
+                  quorum recovery (CLUSTER FAILOVER TAKEOVER): the operator only intervenes
+                  after the cluster has been stuck for the recovery threshold, giving gossip
+                  time to promote replicas on its own where a quorum still exists. Cleared
+                  once the cluster reports cluster_state:ok again.
+                format: date-time
+                type: string
               readyReplicas:
                 description: ReadyReplicas is the count of ready Valkey pods.
                 format: int32

--- a/config/crd/bases/cache.wellcake.io_valkeyclusters.yaml
+++ b/config/crd/bases/cache.wellcake.io_valkeyclusters.yaml
@@ -5085,6 +5085,18 @@ spec:
                   prematurely failed over. Cleared once a master is reachable again.
                 format: date-time
                 type: string
+              quorumDownSince:
+                description: |-
+                  QuorumDownSince is when the operator first observed the Cluster topology
+                  stuck in cluster_state:fail with a majority of primaries unreachable —
+                  the state gossip cannot self-heal, because authorizing a replica failover
+                  needs a master quorum that no longer exists. It debounces operator-driven
+                  quorum recovery (CLUSTER FAILOVER TAKEOVER): the operator only intervenes
+                  after the cluster has been stuck for the recovery threshold, giving gossip
+                  time to promote replicas on its own where a quorum still exists. Cleared
+                  once the cluster reports cluster_state:ok again.
+                format: date-time
+                type: string
               readyReplicas:
                 description: ReadyReplicas is the count of ready Valkey pods.
                 format: int32

--- a/docs/adr/0006-majority-primaries-lost-recovery.md
+++ b/docs/adr/0006-majority-primaries-lost-recovery.md
@@ -1,0 +1,117 @@
+# ADR 0006 — Recovery from a lost primary majority (Cluster topology)
+
+- Status: **Implemented** for **Cluster** topology. Automatic for the **Cache**
+  profile; **opt-in for Durable** via the per-cluster annotation
+  `valkey.wellcake.io/quorum-takeover: "true"` (a forced takeover can drop
+  acknowledged writes, which the Durable profile promises to keep). Validated
+  live on k3d: a 3-shard cluster, majority of primaries fenced, recovered to
+  `cluster_state:ok` with **0 data loss** and the fenced primaries rejoining as
+  replicas. See "Validation" below.
+- Date: 2026-08-04
+- Context: ADR 0004 handles *planned* restarts and *single* primary loss (a
+  replica is promoted, reactively or proactively). It does not cover the
+  disaster where a Cluster loses the **majority of its primaries at once** — an
+  AZ/node-group outage, a bad drain, a correlated crash.
+
+## Context
+
+Valkey Cluster fails a primary over by **vote**: a replica asking to take its
+dead primary's slots needs acknowledgement from a majority of the *masters*.
+That is exactly what a majority-primary loss removes. With `N` primaries and more
+than `floor(N/2)` of them down, the survivors are not a quorum, so **no replica
+can be voted in**. The cluster sits in `cluster_state:fail` with unserved slots
+**indefinitely** — the surviving replicas of the dead primaries are healthy and
+current, but gossip will never promote them. This is a genuine SPOF for the
+Cluster topology (the AR1 gap): the data is there, but nothing brings it back.
+
+The one Valkey primitive that breaks the deadlock is `CLUSTER FAILOVER TAKEOVER`:
+a replica promotes itself **unilaterally**, bumping its `configEpoch` above every
+peer and claiming its primary's slots **without a vote**. It is powerful and
+correspondingly dangerous — run it while the old primary is still serving and you
+get two owners for the same slots (split-brain). Gossip therefore never issues it
+on its own; a human (or an operator) must decide the old primary is really gone.
+
+An operator is well placed to make that call, because it sees something gossip
+cannot: **pod and node liveness through the k8s API**, plus a direct out-of-band
+connection to every node.
+
+## Decision
+
+Add an operator-driven recovery path (`maybeRecoverClusterQuorum`, ahead of the
+allReady-gated scale/survey steps so it runs *during* the outage). It intervenes
+only when **all** of the following hold:
+
+1. **Enabled for this cluster** — Cache by default; Durable only with the opt-in
+   annotation. Availability-first vs durability-first is a per-workload choice.
+2. **Below a voting quorum** — from `CLUSTER NODES`, `healthyMasters*2 <=
+   totalMasters`. With a quorum intact, gossip can (and should) heal on its own,
+   or deliberately refuse under the Durable replica-validity factor; the operator
+   must not race or overrule it. A minority of primaries down is left alone.
+3. **Stuck for the debounce** — `cluster_state != ok` continuously for
+   `quorumRecoveryDownAfter` (45s). Gossip promotes a recoverable failure within
+   seconds; only an unrecoverable one stays stuck this long.
+4. **Each dead primary is fenced from two independent perspectives:**
+   - **k8s view** — the pod is missing, not Running, not Ready, or on a NotReady/
+     absent node; AND
+   - **data-path view** — the operator cannot reach it, or reaches it and it
+     reports `cluster_state:fail` (it has detected its own minority isolation).
+     A primary reachable **and** reporting `cluster_state:ok` is genuinely
+     serving and is **never** taken over.
+
+For each such shard the operator deletes the dead primary's pod (fencing it and
+letting the StatefulSet re-create it) and issues `CLUSTER FAILOVER TAKEOVER` on
+the shard's most up-to-date reachable replica. The re-created old primary rejoins
+through its retained data PVC, sees the higher `configEpoch`, and demotes itself
+to a replica — the cluster self-heals back to full redundancy.
+
+### Why this is not split-brain (the honest argument)
+
+Write safety does **not** rest on proving the old primary's process is dead — no
+k8s operator can do that without STONITH, and on a control-plane partition a
+pod on a NotReady node may still be running. It rests on a guarantee Valkey
+Cluster already makes: **a primary partitioned from the majority of masters for
+longer than `cluster-node-timeout` stops accepting writes** (it returns
+`CLUSTERDOWN`, because a replica on the majority side may have been promoted).
+The debounce (45s) is an order of magnitude above the operator's node-timeout
+(5s), so by the time a takeover fires, any still-running-but-isolated old primary
+has already stopped serving writes. The k8s fence and the data-path check are
+defence in depth on top of that: they decide *when* to intervene and refuse to
+overrule a primary that is demonstrably still serving.
+
+Residual, accepted limits: a minority primary may still answer **stale reads**
+until it rejoins (the Cache profile, the only one that recovers automatically,
+accepts this AP trade-off); and a pathological *asymmetric* partition is outside
+what any voteless takeover can fully rule out. Durable clusters opt in
+deliberately, or stay stuck for a human to resolve.
+
+## Consequences
+
+- The Cluster topology recovers automatically from a lost primary majority
+  (Cache), closing the AR1 SPOF, with a clear, auditable trail (structured logs
+  + the `failover_total{reason="cluster-takeover"}` metric + the
+  `status.quorumDownSince` debounce marker).
+- Durable clusters keep their no-silent-loss contract by default; recovering
+  them is a conscious opt-in.
+- A shard that lost **every** pod (primary and all replicas) is *not* recovered
+  by takeover — there is nothing to promote. That is a restore, out of scope
+  here, and is logged as such.
+- The feature is Cluster-only; Replication/Sentinel already fail over reactively
+  (ADR 0004) and have no quorum to lose.
+
+## Validation
+
+Live on a dedicated k3d cluster (3 shards, 1 replica each, Cache profile,
+Valkey 8.0):
+
+1. Loaded 500 keys; cordoned all nodes; force-deleted 2 of 3 primary pods so they
+   stayed Pending (fenced) while their replicas kept running — a true majority
+   loss (`cluster_state:fail`, `healthy=1/3`).
+2. The operator armed the debounce (`quorum lost and recoverable; starting
+   recovery debounce`), waited 45s, then issued `CLUSTER FAILOVER TAKEOVER` on
+   both surviving replicas.
+3. Result: `cluster_state:ok`, all 16384 slots served, `cluster_size:3`, **500/500
+   keys intact**. The takeover replicas carried `configEpoch` bumped above the
+   fenced primaries.
+4. Uncordoned: the two fenced primaries rescheduled (retained PVC) and rejoined
+   as **replicas** of the new primaries — full redundancy restored, no operator
+   action needed. `status.quorumDownSince` cleared on `cluster_state:ok`.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -388,6 +388,41 @@ The operator does not intervene. The Sentinel quorum elects a new primary;
 clients learn it via `SENTINEL get-master-addr-by-name`. The operator only
 maintains the StatefulSets, ConfigMaps, and Services.
 
+## Cluster: recovering from a lost primary majority (ADR 0006)
+
+A Cluster fails a single primary over by gossip vote, which needs a **majority of
+masters**. If it loses more than half its primaries at once (an AZ/node-group
+outage, a bad drain), the survivors are not a quorum and gossip **cannot** promote
+the healthy, current replicas of the dead primaries — the cluster stays in
+`cluster_state:fail` with unserved slots indefinitely.
+
+The operator recovers this automatically for the **Cache** profile. It only acts
+once the survivors are provably below a quorum, the cluster has been stuck for a
+45s debounce (so it never races a failover gossip could still do), and each dead
+primary is fenced from both the k8s API (pod/node not serving) and a direct
+data-path check. It then issues `CLUSTER FAILOVER TAKEOVER` on the best surviving
+replica of each shard. The re-created primaries rejoin as replicas via their
+retained PVCs — no manual step.
+
+```sh
+# watch it happen
+kubectl -n <ns> get valkeycluster <cluster> -o jsonpath='{.status.quorumDownSince}'  # set while stuck, cleared on recovery
+kubectl -n valkey-operator-system logs deploy/valkey-operator-controller-manager | grep 'quorum recovery'
+# metric: failover_total{reason="cluster-takeover"}
+```
+
+**Durable profile:** recovery is **off by default**, because a forced takeover can
+promote a slightly-behind replica and drop acknowledged writes — the opposite of
+the Durable contract. A stuck Durable cluster waits for a human. Opt in only when
+you accept that trade-off:
+
+```sh
+kubectl -n <ns> annotate valkeycluster <cluster> valkey.wellcake.io/quorum-takeover=true
+```
+
+A shard that lost **every** pod (primary and all its replicas) is not recovered by
+takeover — there is nothing to promote. Restore it from a backup instead.
+
 ## Cluster per-shard workload (ADR 0005, experimental)
 
 With `spec.perShardWorkload: true`, a Cluster is rendered as **one

--- a/internal/controller/cluster.go
+++ b/internal/controller/cluster.go
@@ -57,39 +57,23 @@ func (r *ValkeyClusterReconciler) reconcileCluster(ctx context.Context, vc *cach
 		}
 	}
 
-	// Scale-up: if the spec asks for more replicas than the cluster currently
-	// knows about (Status.LastAppliedReplicas), and all desired pods are
-	// already Ready, run a one-shot add-node Job. Slot rebalance is gated
-	// by spec.autoReshard.
-	if vc.Status.ClusterInitialized && allReady && vc.Status.LastAppliedReplicas < want {
-		result, err := r.runClusterScaleUp(ctx, vc, password)
-		if err != nil || !result.IsZero() {
-			return result, err
-		}
+	// Quorum recovery (closes the Cluster-topology SPOF of AR1): a Cluster that
+	// has lost the majority of its primaries is stuck in cluster_state:fail —
+	// gossip cannot vote a failover without a master quorum. The operator detects
+	// it and drives CLUSTER FAILOVER TAKEOVER on surviving replicas after fencing
+	// the dead primaries via the k8s API. Automatic for Cache; opt-in for Durable
+	// (a forced takeover can drop acknowledged writes). This must run even when
+	// not all pods are Ready — an unready majority is exactly the outage it repairs
+	// — so it sits ahead of the allReady-gated scale/reshard/survey steps below.
+	if res, handled, rerr := r.maybeRecoverClusterQuorum(ctx, vc, password); handled {
+		return res, rerr
 	}
 
-	// Scale-down: if the spec wants fewer replicas than the cluster currently
-	// has (Status.LastAppliedReplicas), run the scale-down Job that reshards
-	// slots away from the leaving masters and del-nodes them. The StatefulSet
-	// is held at the old size by statefulSetReplicas() until this Job
-	// succeeds — otherwise pods owning slots would be deleted and lose data.
-	if vc.Status.ClusterInitialized && vc.Status.LastAppliedReplicas > want {
-		result, err := r.runClusterScaleDown(ctx, vc, password)
-		if err != nil || !result.IsZero() {
-			return result, err
-		}
-	}
-
-	// Manual reshard request (valkey.wellcake.io/reshard): run a one-off rebalance
-	// once per distinct token. Only when the cluster is initialized and all
-	// pods are Ready so the rebalance sees a stable membership.
-	if vc.Status.ClusterInitialized && allReady {
-		if tok := vc.Annotations[reshardAnnotation]; tok != "" && tok != vc.Status.LastReshardToken {
-			result, err := r.runClusterReshard(ctx, vc, password, tok)
-			if err != nil || !result.IsZero() {
-				return result, err
-			}
-		}
+	// One-shot membership operations (scale-up add-node, scale-down reshard-away,
+	// manual reshard): each runs a Job and short-circuits the reconcile while in
+	// flight. Extracted to keep this function under the complexity budget.
+	if res, handled, rerr := r.maybeReconcileClusterScaling(ctx, vc, password, want, allReady); handled {
+		return res, rerr
 	}
 
 	// Proactive rolling restart (ADR 0004): when opted in and the cluster is in
@@ -133,6 +117,43 @@ func (r *ValkeyClusterReconciler) maybeDriveClusterRollout(
 	}
 	if rolling {
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, true, nil
+	}
+	return ctrl.Result{}, false, nil
+}
+
+// maybeReconcileClusterScaling advances the one-shot membership operations —
+// scale-up (add-node), scale-down (reshard slots away + del-node) and a manual
+// reshard request — each of which runs a Job and short-circuits the reconcile
+// while in flight. Returns handled=true (with the Job's result) when one is in
+// progress or just started; handled=false when there is nothing to do and normal
+// reconciliation should continue. Scale-up and reshard require a stable, all-Ready
+// membership; scale-down is gated on the replica count alone because
+// statefulSetReplicas() holds the STS at its old size until the reshard completes.
+func (r *ValkeyClusterReconciler) maybeReconcileClusterScaling(
+	ctx context.Context, vc *cachev1beta1.ValkeyCluster, password string, want int32, allReady bool,
+) (ctrl.Result, bool, error) {
+	if !vc.Status.ClusterInitialized {
+		return ctrl.Result{}, false, nil
+	}
+	if allReady && vc.Status.LastAppliedReplicas < want {
+		result, err := r.runClusterScaleUp(ctx, vc, password)
+		if err != nil || !result.IsZero() {
+			return result, true, err
+		}
+	}
+	if vc.Status.LastAppliedReplicas > want {
+		result, err := r.runClusterScaleDown(ctx, vc, password)
+		if err != nil || !result.IsZero() {
+			return result, true, err
+		}
+	}
+	if allReady {
+		if tok := vc.Annotations[reshardAnnotation]; tok != "" && tok != vc.Status.LastReshardToken {
+			result, err := r.runClusterReshard(ctx, vc, password, tok)
+			if err != nil || !result.IsZero() {
+				return result, true, err
+			}
+		}
 	}
 	return ctrl.Result{}, false, nil
 }

--- a/internal/controller/cluster_recovery.go
+++ b/internal/controller/cluster_recovery.go
@@ -1,0 +1,514 @@
+/*
+Copyright 2026 The Wellcake Authors.
+*/
+
+package controller
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	cachev1beta1 "github.com/melancholictheory/wellcake/api/v1beta1"
+)
+
+// quorumRecoveryDownAfter is how long the operator observes a Cluster stuck in
+// cluster_state:fail — with the surviving primaries below a voting quorum and a
+// recoverable, fenced primary majority — before it drives recovery. It is
+// deliberately longer than the Replication failover debounce: gossip promotes
+// replicas on its own wherever a master quorum still exists, and the operator
+// must not race that. It only steps in for the one state gossip cannot fix — a
+// lost majority — which stays stuck indefinitely, so a generous window costs
+// nothing but rules out a transient blip masquerading as quorum loss.
+const quorumRecoveryDownAfter = 45 * time.Second
+
+// quorumTakeoverAnnotation force-enables (or force-disables) automatic quorum
+// recovery for a cluster, overriding the profile default. Cache clusters recover
+// automatically; Durable clusters default OFF, because a forced CLUSTER FAILOVER
+// TAKEOVER can promote a replica that Valkey's replica-validity factor would
+// refuse, silently dropping acknowledged writes — a trade-off a Durable operator
+// must accept explicitly.
+const quorumTakeoverAnnotation = "valkey.wellcake.io/quorum-takeover"
+
+// quorumTakeoverTarget is one shard the operator will recover: the dead primary
+// to fence and the surviving replica to promote in its place.
+type quorumTakeoverTarget struct {
+	primaryPod string
+	primaryID  string
+	replicaPod string
+}
+
+// quorumRecoveryEnabled reports whether automatic quorum recovery is allowed for
+// this cluster. Cache: yes by default (availability-first). Durable: only when
+// explicitly opted in via the annotation, because a forced takeover can drop
+// acknowledged writes the Durable profile promises to keep. An explicit
+// annotation value always wins (it can also disable recovery for a Cache cluster).
+func quorumRecoveryEnabled(vc *cachev1beta1.ValkeyCluster) bool {
+	if v, err := strconv.ParseBool(vc.Annotations[quorumTakeoverAnnotation]); err == nil {
+		return v
+	}
+	return vc.Spec.Profile != cachev1beta1.ProfileDurable
+}
+
+// maybeRecoverClusterQuorum detects and recovers a Cluster that has lost the
+// majority of its primaries — the one failure mode gossip cannot self-heal,
+// because authorizing a replica failover needs a master quorum that no longer
+// exists. Such a cluster sits in cluster_state:fail indefinitely with unserved
+// slots; the surviving replicas of the dead primaries wait for votes that can
+// never come.
+//
+// The operator breaks the deadlock with two things gossip lacks: a view of pod
+// and node liveness through the k8s API, and a direct out-of-band connection to
+// each node. It intervenes ONLY when all of the following hold, so it never races
+// a failover gossip could still perform and never overrules a primary that might
+// still be serving:
+//
+//   - the surviving primaries are below a voting quorum (healthy*2 <= total) —
+//     gossip provably cannot promote on its own;
+//   - the cluster has been stuck this way for quorumRecoveryDownAfter;
+//   - each dead primary is BOTH k8s-fenced (pod/node confirmed not serving via
+//     the k8s API) AND not observably serving on its data path (unreachable, or
+//     reachable but reporting cluster_state:fail). A primary reachable AND
+//     reporting cluster_state:ok is genuinely serving and is never taken over.
+//
+// Write split-brain safety does NOT rest on proving the old primary's process is
+// dead — no k8s operator can do that without STONITH, and on a control-plane
+// partition a NotReady/absent-node pod may still be running. It rests on Valkey
+// Cluster's own guarantee: a primary partitioned from the majority of masters for
+// longer than cluster-node-timeout stops accepting writes (returns CLUSTERDOWN),
+// because a replica on the majority side may have been promoted. quorumRecovery
+// DownAfter (45s) is an order of magnitude above the operator's node-timeout
+// (5s), so by the time a takeover fires, a still-running-but-isolated old primary
+// has already stopped serving writes. The k8s fence and the data-path check are
+// defence in depth on top of that — they decide WHEN to intervene and refuse to
+// overrule a primary that is demonstrably still serving. (A minority primary may
+// still answer stale READS until it rejoins; the Cache profile, the only one that
+// recovers automatically, accepts that AP trade-off — Durable is opt-in.)
+//
+// Returns handled=true (with a fast requeue) while recovery is pending or in
+// flight; handled=false when the cluster is healthy, recovery is disabled, or
+// nothing is safely recoverable and normal reconciliation should continue.
+func (r *ValkeyClusterReconciler) maybeRecoverClusterQuorum(
+	ctx context.Context, vc *cachev1beta1.ValkeyCluster, password string,
+) (ctrl.Result, bool, error) {
+	log := logf.FromContext(ctx)
+	if !vc.Status.ClusterInitialized {
+		return ctrl.Result{}, false, nil
+	}
+	if !quorumRecoveryEnabled(vc) {
+		// Disabled (Durable without opt-in, or explicitly turned off) — don't
+		// leave a stale debounce marker behind if it was toggled mid-incident.
+		r.clearQuorumDown(ctx, vc)
+		return ctrl.Result{}, false, nil
+	}
+
+	// Dial ANY reachable pod — pod-0 may itself be one of the dead primaries, so
+	// unlike surveyCluster we walk every pod until one answers.
+	c := r.dialAnyClusterPod(ctx, vc, password)
+	if c == nil {
+		// Nothing reachable: a total outage, or the operator is partitioned from
+		// the data plane. Either way we can neither confirm state nor fence
+		// safely — do nothing and let the normal requeue retry.
+		return ctrl.Result{}, false, nil
+	}
+	defer c.close()
+
+	info, err := c.clusterInfoMap(ctx)
+	if err != nil {
+		return ctrl.Result{}, false, nil
+	}
+	if info["cluster_state"] == "ok" {
+		// Healthy — gossip is coping or has already recovered. This is the ONLY
+		// place the debounce marker is cleared, so transient probe errors below
+		// never reset the clock.
+		r.clearQuorumDown(ctx, vc)
+		return ctrl.Result{}, false, nil
+	}
+
+	raw, err := c.clusterNodes(ctx)
+	if err != nil {
+		return ctrl.Result{}, false, nil
+	}
+	nodes := parseClusterNodes(raw)
+
+	// Majority gate: intervene only when the surviving primaries are NOT a voting
+	// quorum, so gossip provably cannot promote on its own. With a quorum intact,
+	// gossip will heal a genuine primary loss (or deliberately refuse under the
+	// Durable validity factor), and the operator must not race or overrule it —
+	// so a mere cluster_state:fail with a minority of primaries down is left alone.
+	healthy, total := countMasters(nodes)
+	if total == 0 || healthy*2 > total {
+		return ctrl.Result{}, false, nil
+	}
+
+	targets := r.recoverableShards(ctx, vc, password, nodes)
+	if len(targets) == 0 {
+		// Stuck below quorum but nothing SAFELY recoverable right now (a shard
+		// that lost every pod needs a restore; a "down" primary still reachable
+		// and serving must not be overruled; or a transient probe error). Do not
+		// clear the marker — only cluster_state:ok does that — so an API blip
+		// cannot reset the debounce clock. Take no action.
+		return ctrl.Result{}, false, nil
+	}
+
+	// Debounce: act only after the cluster has been stuck below quorum for the
+	// whole window.
+	if !r.quorumDownLongEnough(ctx, vc, log) {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, true, nil
+	}
+
+	// Note: the marker is intentionally NOT cleared here. Clearing happens only on
+	// the observed cluster_state:ok above — so if a recovery attempt fails, the
+	// next pass (debounce already elapsed) retries immediately instead of
+	// re-waiting the whole window.
+	for _, t := range targets {
+		r.recoverShard(ctx, vc, password, c.port, t, log)
+	}
+
+	// Requeue quickly to observe recovery: slots re-served, cluster_state:ok, the
+	// fenced primaries re-created by their StatefulSet rejoin as replicas.
+	return ctrl.Result{RequeueAfter: 5 * time.Second}, true, nil
+}
+
+// recoverShard fences one dead primary and promotes its surviving replica. It
+// re-confirms the primary is not serving RIGHT BEFORE acting (a fresh split-brain
+// guard, since the debounce window may have changed things), then fences the pod
+// and issues the takeover. Fencing (deleting the pod) precedes the takeover as
+// defence in depth: the primary is already proven not-serving, but deleting it
+// first also lets the StatefulSet re-create it — it rejoins as a replica of the
+// new primary through its retained data PVC (same node ID, it sees the higher
+// configEpoch and demotes). Per-shard errors are logged and the next reconcile
+// retries; one bad shard does not block the others.
+func (r *ValkeyClusterReconciler) recoverShard(
+	ctx context.Context, vc *cachev1beta1.ValkeyCluster, password string, port int32,
+	t quorumTakeoverTarget, log logr.Logger,
+) {
+	// Fresh guards, re-evaluated right before acting because the debounce window
+	// may have changed things: the primary must STILL be k8s-fenced AND still not
+	// serving. Re-checking the fence closes the window where the pod returned to
+	// Running+Ready on a Ready node during the wait.
+	fenced, err := r.primaryFencedByK8s(ctx, vc, t.primaryPod)
+	if err != nil || !fenced {
+		log.Info("quorum recovery: primary no longer fenced by k8s — aborting takeover",
+			"name", vc.Name, "primary", t.primaryPod)
+		return
+	}
+	if r.primaryStillServing(ctx, vc, password, t.primaryPod) {
+		log.Info("quorum recovery: primary is serving again (cluster_state:ok) — aborting takeover",
+			"name", vc.Name, "primary", t.primaryPod)
+		return
+	}
+
+	log.Info("quorum recovery: fencing dead primary and taking over on replica",
+		"name", vc.Name, "deadPrimary", t.primaryPod, "promote", t.replicaPod, "nodeID", t.primaryID)
+
+	if err := r.deletePodByName(ctx, vc, t.primaryPod); err != nil {
+		log.Error(err, "quorum recovery: failed to fence dead primary; skipping takeover this pass",
+			"pod", t.primaryPod)
+		return
+	}
+
+	rc := dialReplClient(ctx, podFQDN(vc, t.replicaPod), port, password,
+		tlsEnabled(vc), loadMTLSClientCert(ctx, r, vc), 3*time.Second)
+	if rc == nil {
+		log.Error(nil, "quorum recovery: replica unreachable at takeover; will retry", "replica", t.replicaPod)
+		return
+	}
+	defer rc.close()
+
+	if err := rc.clusterFailoverTakeover(ctx); err != nil {
+		log.Error(err, "quorum recovery: CLUSTER FAILOVER TAKEOVER failed", "replica", t.replicaPod)
+		return
+	}
+	failoverTotal.WithLabelValues(vc.Namespace, vc.Name, "cluster-takeover").Inc()
+	log.Info("quorum recovery: takeover issued", "name", vc.Name, "newPrimary", t.replicaPod)
+}
+
+// recoverableShards returns, for each down primary that is SAFE to recover, the
+// dead primary and the surviving replica to promote. A shard qualifies only when
+// ALL hold:
+//   - its primary is unhealthy in CLUSTER NODES (fail/fail?/noaddr, or a
+//     disconnected bus link);
+//   - its node name maps to a real data pod of THIS cluster — a CLUSTER NODES
+//     entry that parsed to a bare IP (no announce hostname) is never mistaken for
+//     a fenced pod of ours (its Get would 404 and look "fenced");
+//   - the primary pod is k8s-FENCED — not serving per the k8s API (missing, not
+//     Running, not Ready, or on a NotReady/absent node);
+//   - AND the primary is confirmed not serving on its data path — unreachable, or
+//     reachable but reporting cluster_state:fail (it has detected its own minority
+//     isolation and stopped serving, Valkey's built-in partition protection). A
+//     primary reachable AND reporting cluster_state:ok is genuinely serving and is
+//     refused. Requiring BOTH the k8s view and this direct check is what closes
+//     the split-brain window: k8s-dead-but-still-serving (control-plane partition)
+//     is caught by the data-path check, and briefly-unreachable-but-alive (a GC
+//     blip) is caught by the k8s view;
+//   - at least one of its replicas is reachable (the takeover target). Among
+//     reachable replicas the most up-to-date (highest slave_repl_offset) wins.
+//
+// A shard that lost every pod has no replica to promote and is skipped — it needs
+// a restore, which is out of scope for automatic recovery.
+func (r *ValkeyClusterReconciler) recoverableShards(
+	ctx context.Context, vc *cachev1beta1.ValkeyCluster, password string, nodes []clusterNode,
+) []quorumTakeoverTarget {
+	log := logf.FromContext(ctx)
+	known := knownDataPods(vc)
+
+	replicasByMaster := map[string][]clusterNode{}
+	for _, n := range nodes {
+		// Only real data pods of THIS cluster are eligible promotion targets —
+		// same guard the primaries get, so a bare-IP/foreign node name is never
+		// dialed as a candidate replica.
+		if !n.isMaster() && n.masterID != "" && known[n.podName] {
+			replicasByMaster[n.masterID] = append(replicasByMaster[n.masterID], n)
+		}
+	}
+
+	var out []quorumTakeoverTarget
+	for _, n := range nodes {
+		if !n.isMaster() || n.isHealthy() {
+			continue // only DOWN primaries are recovery candidates
+		}
+		if n.podName == "" || !known[n.podName] {
+			log.Info("quorum recovery: down primary does not map to a known data pod; skipping",
+				"name", vc.Name, "podName", n.podName)
+			continue
+		}
+		fenced, err := r.primaryFencedByK8s(ctx, vc, n.podName)
+		if err != nil {
+			log.Error(err, "quorum recovery: could not evaluate primary liveness; skipping", "pod", n.podName)
+			continue
+		}
+		if !fenced {
+			log.Info("quorum recovery: down primary still Running+Ready per k8s — not taking over (split-brain guard)",
+				"name", vc.Name, "primary", n.podName)
+			continue
+		}
+		if r.primaryStillServing(ctx, vc, password, n.podName) {
+			log.Info("quorum recovery: down primary still reachable and reports cluster_state:ok — refusing takeover (split-brain guard)",
+				"name", vc.Name, "primary", n.podName)
+			continue
+		}
+		replica := r.pickTakeoverReplica(ctx, vc, password, replicasByMaster[n.id])
+		if replica == "" {
+			log.Info("quorum recovery: down primary has no reachable replica — shard needs restore, skipping",
+				"name", vc.Name, "primary", n.podName)
+			continue
+		}
+		out = append(out, quorumTakeoverTarget{primaryPod: n.podName, primaryID: n.id, replicaPod: replica})
+	}
+	return out
+}
+
+// countMasters returns (healthy, total) masters from a CLUSTER NODES view. A
+// "healthy" master is one not flagged fail/fail? with a connected bus link — i.e.
+// one that could still cast a failover vote. Used by the majority gate to decide
+// whether gossip still has a quorum to promote replicas on its own.
+func countMasters(nodes []clusterNode) (healthy, total int) {
+	for _, n := range nodes {
+		if !n.isMaster() {
+			continue
+		}
+		total++
+		if n.isHealthy() {
+			healthy++
+		}
+	}
+	return healthy, total
+}
+
+// knownDataPods returns the set of pod names that legitimately belong to this
+// Cluster's data plane, so a CLUSTER NODES entry that parsed to a bare IP (no
+// announce hostname) or any other unexpected name is never mistaken for a fenced
+// pod of ours.
+func knownDataPods(vc *cachev1beta1.ValkeyCluster) map[string]bool {
+	out := map[string]bool{}
+	for _, p := range clusterDataPods(vc) {
+		out[podNameFromFQDN(p.host)] = true
+	}
+	return out
+}
+
+// primaryStillServing reports whether the (allegedly down) primary is OBSERVABLY
+// still serving: reachable from the operator AND reporting cluster_state:ok. That
+// is the one state a takeover must never override, so it returns true only then.
+//
+// A false result means "not observably serving", NOT a proof the process is dead:
+// unreachable (the common case — pod/node gone) and reachable-but-cluster_state
+// :fail (it detected its own minority isolation) both return false. Write safety
+// for the unreachable case does not come from this check but from Valkey's
+// minority-write-block plus the quorumRecoveryDownAfter debounce (see
+// maybeRecoverClusterQuorum); this check's job is to refuse takeover of a primary
+// that is provably still serving.
+func (r *ValkeyClusterReconciler) primaryStillServing(ctx context.Context, vc *cachev1beta1.ValkeyCluster, password, podName string) bool {
+	port := valkeyPort
+	if tlsEnabled(vc) {
+		port = valkeyTLSPort
+	}
+	c := dialReplClient(ctx, podFQDN(vc, podName), port, password,
+		tlsEnabled(vc), loadMTLSClientCert(ctx, r, vc), 2*time.Second)
+	if c == nil {
+		return false // unreachable → serving no one → safe to take over
+	}
+	defer c.close()
+	info, err := c.clusterInfoMap(ctx)
+	if err != nil {
+		return false // cannot confirm it is serving → treat as not serving
+	}
+	return info["cluster_state"] == "ok"
+}
+
+// pickTakeoverReplica dials each of a dead primary's replicas and returns the pod
+// name of the reachable one with the highest replication offset — the least data
+// behind, so promoting it loses the least. A direct dial (not the gossip health
+// flag) is the authority on which replica is actually alive. Returns "" if none
+// answer.
+func (r *ValkeyClusterReconciler) pickTakeoverReplica(
+	ctx context.Context, vc *cachev1beta1.ValkeyCluster, password string, replicas []clusterNode,
+) string {
+	port := valkeyPort
+	if tlsEnabled(vc) {
+		port = valkeyTLSPort
+	}
+	best := ""
+	var bestOff int64 = -1
+	for _, rep := range replicas {
+		if rep.podName == "" {
+			continue
+		}
+		rc := dialReplClient(ctx, podFQDN(vc, rep.podName), port, password,
+			tlsEnabled(vc), loadMTLSClientCert(ctx, r, vc), 2*time.Second)
+		if rc == nil {
+			continue
+		}
+		info, err := rc.info(ctx)
+		rc.close()
+		if err != nil {
+			continue
+		}
+		off := int64(0)
+		if v, ok := info["slave_repl_offset"]; ok {
+			if n, e := strconv.ParseInt(v, 10, 64); e == nil {
+				off = n
+			}
+		}
+		if off > bestOff {
+			bestOff = off
+			best = rep.podName
+		}
+	}
+	return best
+}
+
+// primaryFencedByK8s reports whether the named primary pod is NOT serving clients
+// per the k8s API. True when the pod is missing, not in the Running phase, not
+// Ready, or on a Node that is NotReady or gone. False when the pod is Running AND
+// Ready on a Ready node.
+//
+// This is only ONE half of the fence: a NotReady/absent node means the kubelet
+// cannot report a live process, but on a pure control-plane partition the process
+// may still be running, so the caller ALSO requires primaryStillServing==false
+// (a direct data-path check) before taking over. Conversely, the Running+Ready
+// case here guards the opposite error — never overruling a pod k8s still believes
+// is alive on the strength of a transient Valkey unreachability.
+func (r *ValkeyClusterReconciler) primaryFencedByK8s(ctx context.Context, vc *cachev1beta1.ValkeyCluster, podName string) (bool, error) {
+	var pod corev1.Pod
+	err := r.Get(ctx, types.NamespacedName{Namespace: vc.Namespace, Name: podName}, &pod)
+	if apierrors.IsNotFound(err) {
+		return true, nil // pod gone → fenced (per k8s)
+	}
+	if err != nil {
+		return false, err
+	}
+	if pod.Status.Phase != corev1.PodRunning || !podIsReady(&pod) {
+		return true, nil // crashed / terminating / not Ready → fenced
+	}
+	if pod.Spec.NodeName == "" {
+		return false, nil // Running but unscheduled is impossible in practice; be conservative
+	}
+	ready, err := r.nodeReady(ctx, pod.Spec.NodeName)
+	if err != nil {
+		return false, err
+	}
+	// Live pod on a live node → NOT fenced; dead/absent node → stale-Ready pod → fenced.
+	return !ready, nil
+}
+
+// nodeReady reports whether the named Node currently has Ready=True. A missing
+// node counts as not-ready — it was deleted out from under its pods, which are
+// therefore gone too.
+func (r *ValkeyClusterReconciler) nodeReady(ctx context.Context, name string) (bool, error) {
+	var node corev1.Node
+	if err := r.Get(ctx, types.NamespacedName{Name: name}, &node); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status == corev1.ConditionTrue, nil
+		}
+	}
+	return false, nil
+}
+
+// dialAnyClusterPod returns a client to the first reachable Cluster data pod, or
+// nil if none answer. Unlike surveyCluster (which only tries pod-0), this walks
+// every pod so a cluster whose pod-0 is itself a dead primary can still be
+// surveyed and recovered.
+func (r *ValkeyClusterReconciler) dialAnyClusterPod(ctx context.Context, vc *cachev1beta1.ValkeyCluster, password string) *replClient {
+	port := valkeyPort
+	if tlsEnabled(vc) {
+		port = valkeyTLSPort
+	}
+	for _, p := range clusterDataPods(vc) {
+		if c := dialReplClient(ctx, p.host, port, password,
+			tlsEnabled(vc), loadMTLSClientCert(ctx, r, vc), 2*time.Second); c != nil {
+			return c
+		}
+	}
+	return nil
+}
+
+// quorumDownLongEnough records (on first observation) when the cluster went
+// recoverably-stuck and reports whether it has now been stuck for at least
+// quorumRecoveryDownAfter. The timestamp is persisted in status so the window
+// survives across reconciles.
+func (r *ValkeyClusterReconciler) quorumDownLongEnough(ctx context.Context, vc *cachev1beta1.ValkeyCluster, log logr.Logger) bool {
+	if vc.Status.QuorumDownSince == nil {
+		now := metav1.Now()
+		log.Info("cluster quorum lost and recoverable; starting recovery debounce",
+			"name", vc.Name, "downAfter", quorumRecoveryDownAfter.String())
+		r.setQuorumDown(ctx, vc, &now)
+		return false
+	}
+	return downElapsed(vc.Status.QuorumDownSince.Time, time.Now(), quorumRecoveryDownAfter)
+}
+
+func (r *ValkeyClusterReconciler) clearQuorumDown(ctx context.Context, vc *cachev1beta1.ValkeyCluster) {
+	if vc.Status.QuorumDownSince != nil {
+		r.setQuorumDown(ctx, vc, nil)
+	}
+}
+
+// setQuorumDown persists the QuorumDownSince marker via its OWN status patch with
+// a base captured before the mutation, so the change lands in the diff (the later
+// updateClusterStatus patch captures its base after this and leaves the field
+// untouched). Best-effort: a failed patch just means the next reconcile
+// re-evaluates the window.
+func (r *ValkeyClusterReconciler) setQuorumDown(ctx context.Context, vc *cachev1beta1.ValkeyCluster, t *metav1.Time) {
+	base := client.MergeFrom(vc.DeepCopy())
+	vc.Status.QuorumDownSince = t
+	if err := r.Status().Patch(ctx, vc, base); err != nil {
+		logf.FromContext(ctx).V(1).Info("quorum-down marker patch failed (will re-evaluate)", "err", err.Error())
+	}
+}

--- a/internal/controller/cluster_recovery_test.go
+++ b/internal/controller/cluster_recovery_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2026 The Wellcake Authors.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	cachev1beta1 "github.com/melancholictheory/wellcake/api/v1beta1"
+)
+
+func mkFencePod(node string, phase corev1.PodPhase, ready bool) *corev1.Pod {
+	cond := corev1.ConditionFalse
+	if ready {
+		cond = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "c-0"},
+		Spec:       corev1.PodSpec{NodeName: node},
+		Status: corev1.PodStatus{
+			Phase:      phase,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: cond}},
+		},
+	}
+}
+
+func mkNode(name string, ready bool) *corev1.Node {
+	cond := corev1.ConditionFalse
+	if ready {
+		cond = corev1.ConditionTrue
+	}
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: cond}}},
+	}
+}
+
+// TestPrimaryFencedByK8s locks down the split-brain guard: the operator may take
+// a down primary's slots over ONLY when the pod is provably not serving, and must
+// REFUSE when the pod is Running+Ready on a Ready node — where (with only a TCP
+// readiness probe) it might still be serving clients on the far side of a
+// Valkey-level partition.
+func TestPrimaryFencedByK8s(t *testing.T) {
+	ns := "ns"
+	vc := &cachev1beta1.ValkeyCluster{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "c"}}
+
+	cases := []struct {
+		name string
+		objs []client.Object
+		want bool
+	}{
+		{
+			name: "pod missing → fenced",
+			objs: nil,
+			want: true,
+		},
+		{
+			name: "pod not Running (Failed) → fenced",
+			objs: []client.Object{mkFencePod("n1", corev1.PodFailed, false), mkNode("n1", true)},
+			want: true,
+		},
+		{
+			name: "pod Running but not Ready → fenced",
+			objs: []client.Object{mkFencePod("n1", corev1.PodRunning, false), mkNode("n1", true)},
+			want: true,
+		},
+		{
+			name: "pod Running+Ready but node NotReady → fenced (stale kubelet status)",
+			objs: []client.Object{mkFencePod("n1", corev1.PodRunning, true), mkNode("n1", false)},
+			want: true,
+		},
+		{
+			name: "pod Running+Ready but node gone → fenced",
+			objs: []client.Object{mkFencePod("goneNode", corev1.PodRunning, true)},
+			want: true,
+		},
+		{
+			name: "pod Running+Ready on Ready node → NOT fenced (split-brain guard holds)",
+			objs: []client.Object{mkFencePod("n1", corev1.PodRunning, true), mkNode("n1", true)},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := newTestScheme(t)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objs...).Build()
+			r := &ValkeyClusterReconciler{Client: c, Scheme: scheme}
+			got, err := r.primaryFencedByK8s(context.Background(), vc, "c-0")
+			if err != nil {
+				t.Fatalf("primaryFencedByK8s: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("fenced=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestQuorumDownDebounce verifies the recovery debounce: the first observation
+// only records the marker (so gossip gets its window), and recovery fires only
+// once the cluster has been stuck longer than quorumRecoveryDownAfter.
+func TestQuorumDownDebounce(t *testing.T) {
+	scheme := newTestScheme(t)
+	vc := &cachev1beta1.ValkeyCluster{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "c"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vc).WithStatusSubresource(vc).Build()
+	r := &ValkeyClusterReconciler{Client: c, Scheme: scheme}
+	log := logr.Discard()
+	ctx := context.Background()
+
+	if r.quorumDownLongEnough(ctx, vc, log) {
+		t.Fatal("first observation must start the debounce, not fire")
+	}
+	if vc.Status.QuorumDownSince == nil {
+		t.Fatal("QuorumDownSince should have been recorded on first observation")
+	}
+
+	// Backdate the marker beyond the window: recovery should now fire.
+	old := metav1.NewTime(time.Now().Add(-2 * quorumRecoveryDownAfter))
+	r.setQuorumDown(ctx, vc, &old)
+	if !r.quorumDownLongEnough(ctx, vc, log) {
+		t.Fatal("after the window elapsed, debounce should fire")
+	}
+
+	r.clearQuorumDown(ctx, vc)
+	if vc.Status.QuorumDownSince != nil {
+		t.Fatal("clearQuorumDown should reset the marker")
+	}
+}
+
+// TestCountMasters checks the majority-gate input: only fail/fail?-free,
+// connected masters count as able to vote.
+func TestCountMasters(t *testing.T) {
+	nodes := parseClusterNodes(
+		"a 10.0.0.1:6379@16379,c-0 master - 0 0 1 connected 0-5460\n" +
+			"b 10.0.0.2:6379@16379,c-1 master - 0 0 2 connected 5461-10922\n" +
+			"c 10.0.0.3:6379@16379,c-2 master,fail - 0 0 3 disconnected 10923-16383\n" +
+			"d 10.0.0.4:6379@16379,c-3 slave a 0 0 1 connected\n")
+	healthy, total := countMasters(nodes)
+	if total != 3 {
+		t.Fatalf("total masters=%d, want 3", total)
+	}
+	if healthy != 2 {
+		t.Fatalf("healthy masters=%d, want 2 (one is fail/disconnected)", healthy)
+	}
+	// 3 masters, 2 healthy → 2*2 > 3 → quorum still exists → gate must NOT fire.
+	if healthy*2 <= total {
+		t.Fatal("majority gate would fire with a surviving quorum (2 of 3)")
+	}
+	// Lose a second master → 1 healthy of 3 → 1*2 <= 3 → gate fires.
+	nodes[1].flags = []string{"master", "fail"}
+	nodes[1].linkState = "disconnected"
+	if h, tot := countMasters(nodes); h*2 > tot {
+		t.Fatalf("majority gate should fire at %d/%d healthy", h, tot)
+	}
+}
+
+// TestMajorityGateEvenN checks the even-N boundary: with 4 masters, gossip needs
+// 3 votes (floor(4/2)+1), so exactly 2 healthy is already below quorum and the
+// gate (healthy*2 <= total) must fire; 3 healthy must not.
+func TestMajorityGateEvenN(t *testing.T) {
+	for _, tc := range []struct {
+		healthy, total int
+		wantFire       bool
+	}{
+		{3, 4, false}, // 3 of 4 healthy → quorum intact → leave to gossip
+		{2, 4, true},  // 2 of 4 → below quorum (needs 3) → operator may act
+		{2, 3, false}, // 2 of 3 → quorum intact (needs 2) → leave to gossip
+		{1, 3, true},  // 1 of 3 → below quorum → operator may act
+		{1, 2, true},  // 1 of 2 → below quorum (needs 2) → operator may act
+	} {
+		fire := tc.healthy*2 <= tc.total
+		if fire != tc.wantFire {
+			t.Fatalf("healthy=%d total=%d: gate fires=%v, want %v", tc.healthy, tc.total, fire, tc.wantFire)
+		}
+	}
+}
+
+// TestRecoverableShardsFenceGate verifies the k8s half of the conjunction runs
+// BEFORE any pod is dialled: a down primary whose pod is Running+Ready on a Ready
+// node (not fenced) is filtered out, and so is one whose CLUSTER NODES name is not
+// a known data pod. Both are rejected without a takeover target, using only the
+// fake k8s client (no network).
+func TestRecoverableShardsFenceGate(t *testing.T) {
+	scheme := newTestScheme(t)
+	shards := int32(3)
+	repl := int32(1)
+	vc := &cachev1beta1.ValkeyCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "qtest"},
+		Spec: cachev1beta1.ValkeyClusterSpec{
+			Topology: cachev1beta1.TopologyCluster, Shards: &shards, ReplicasPerShard: &repl,
+		},
+	}
+	// qtest-0 is a down primary but Running+Ready on a Ready node → NOT fenced.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "qtest-0"},
+			Spec:       corev1.PodSpec{NodeName: "n1"},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}},
+		},
+		mkNode("n1", true),
+	).Build()
+	r := &ValkeyClusterReconciler{Client: c, Scheme: scheme}
+
+	nodes := []clusterNode{
+		{id: "m0", podName: "qtest-0", flags: []string{"master", "fail"}, linkState: "disconnected"},  // known but NOT fenced
+		{id: "m1", podName: "10.0.0.9", flags: []string{"master", "fail"}, linkState: "disconnected"}, // unknown name (bare IP)
+		{id: "r0", podName: "qtest-3", flags: []string{"slave"}, masterID: "m0", linkState: "connected"},
+	}
+	got := r.recoverableShards(context.Background(), vc, "", nodes)
+	if len(got) != 0 {
+		t.Fatalf("expected no recoverable shards (one not-fenced, one unknown name), got %d: %+v", len(got), got)
+	}
+}
+
+// TestQuorumRecoveryEnabled checks the profile/annotation gating: Cache recovers
+// by default, Durable only on explicit opt-in, and an explicit annotation always
+// wins.
+func TestQuorumRecoveryEnabled(t *testing.T) {
+	mk := func(profile cachev1beta1.Profile, ann string) *cachev1beta1.ValkeyCluster {
+		vc := &cachev1beta1.ValkeyCluster{Spec: cachev1beta1.ValkeyClusterSpec{Profile: profile}}
+		if ann != "" {
+			vc.Annotations = map[string]string{quorumTakeoverAnnotation: ann}
+		}
+		return vc
+	}
+	cases := []struct {
+		name    string
+		profile cachev1beta1.Profile
+		ann     string
+		want    bool
+	}{
+		{"cache default on", cachev1beta1.ProfileCache, "", true},
+		{"durable default off", cachev1beta1.ProfileDurable, "", false},
+		{"durable opt-in on", cachev1beta1.ProfileDurable, "true", true},
+		{"cache opt-out off", cachev1beta1.ProfileCache, "false", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := quorumRecoveryEnabled(mk(tc.profile, tc.ann)); got != tc.want {
+				t.Fatalf("quorumRecoveryEnabled=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNodeReady covers the node-liveness cross-check the fence relies on.
+func TestNodeReady(t *testing.T) {
+	scheme := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(mkNode("ready", true), mkNode("down", false)).Build()
+	r := &ValkeyClusterReconciler{Client: c, Scheme: scheme}
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		node string
+		want bool
+	}{
+		{"ready", true},
+		{"down", false},
+		{"missing", false}, // a deleted node counts as not-ready
+	} {
+		got, err := r.nodeReady(ctx, tc.node)
+		if err != nil {
+			t.Fatalf("nodeReady(%s): %v", tc.node, err)
+		}
+		if got != tc.want {
+			t.Fatalf("nodeReady(%s)=%v, want %v", tc.node, got, tc.want)
+		}
+	}
+}

--- a/internal/controller/failover.go
+++ b/internal/controller/failover.go
@@ -184,6 +184,40 @@ func (c *replClient) clusterFailover(ctx context.Context) error {
 	return c.rdb.Do(ctx, "CLUSTER", "FAILOVER").Err()
 }
 
+// clusterFailoverTakeover issues CLUSTER FAILOVER TAKEOVER on THIS node (must be
+// a replica). Unlike the graceful CLUSTER FAILOVER, TAKEOVER does NOT coordinate
+// with the (dead) primary and does NOT need a master quorum to authorize the
+// promotion: the replica unilaterally bumps its configEpoch above every peer and
+// claims its primary's slots. It is the ONLY recovery for a Cluster that has lost
+// the majority of its primaries — gossip cannot vote a failover without a quorum.
+// It is unsafe to run while the old primary is alive (two owners for the same
+// slots → split-brain), so the caller MUST fence the primary first (confirm it is
+// gone via the k8s API and delete its pod). See maybeRecoverClusterQuorum.
+func (c *replClient) clusterFailoverTakeover(ctx context.Context) error {
+	return c.rdb.Do(ctx, "CLUSTER", "FAILOVER", "TAKEOVER").Err()
+}
+
+// clusterInfoMap parses `CLUSTER INFO` into a flat key/value map. The operator
+// reads cluster_state ("ok" | "fail") and cluster_slots_assigned from it to tell
+// whether the cluster is currently serving all slots.
+func (c *replClient) clusterInfoMap(ctx context.Context) (map[string]string, error) {
+	res, err := c.rdb.Do(ctx, "CLUSTER", "INFO").Text()
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]string{}
+	for line := range strings.SplitSeq(res, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if i := strings.Index(line, ":"); i > 0 {
+			out[line[:i]] = strings.TrimSpace(line[i+1:])
+		}
+	}
+	return out, nil
+}
+
 // sentinelFailover asks THIS Sentinel to fail the monitored master over to a
 // replica (SENTINEL FAILOVER <name>). The Sentinel quorum picks the best replica
 // (priority/offset), promotes it, and reconfigures the rest. Used by the


### PR DESCRIPTION
A Cluster fails a single primary over by gossip vote, which needs a majority of masters. Lose more than half the primaries at once (an AZ outage, a bad drain, a correlated crash) and the survivors aren't a quorum, so gossip can't vote any replica in. The cluster then sits in `cluster_state:fail` with unserved slots for as long as the outage lasts, even though the dead primaries' replicas are healthy and current. That is a real single point of failure for the Cluster topology: the data is right there, but nothing brings it back.

This adds an operator-driven recovery path for that case.

## How it decides to act

The operator only steps in when all of these hold, so it never races a failover gossip could still do and never overrules a primary that might still be serving:

- Recovery is enabled for the cluster. Cache by default; Durable only with the `valkey.wellcake.io/quorum-takeover: "true"` annotation.
- The survivors are below a voting quorum: from `CLUSTER NODES`, `healthyMasters*2 <= totalMasters`. A minority of primaries down is left to gossip.
- The cluster has been stuck for a 45s debounce.
- Each dead primary is fenced from two independent perspectives: the k8s API (pod missing, not Running, not Ready, or on a NotReady node) and a direct data-path check (unreachable, or reachable but reporting `cluster_state:fail`). A primary that is reachable and reports `cluster_state:ok` is genuinely serving, and is never taken over.

It then deletes the dead primary's pod and runs `CLUSTER FAILOVER TAKEOVER` on the shard's most up-to-date reachable replica. The re-created primary rejoins through its retained PVC, sees the higher `configEpoch`, and demotes itself, so full redundancy comes back without any manual step.

## Why it isn't split-brain

Write safety doesn't depend on proving the old primary's process is dead. No operator can do that without STONITH. It depends on a guarantee Valkey already makes: a primary partitioned from the majority for longer than `cluster-node-timeout` stops accepting writes. The 45s debounce is far longer than the 5s node-timeout, so by the time a takeover fires, a still-running but isolated old primary has already stopped serving writes. The k8s fence and the data-path check sit on top of that as defence in depth. A minority primary can still answer stale reads until it rejoins, which the Cache profile accepts and Durable opts into. The full argument is in ADR 0006.

## A cross-model review shaped the safety design

An adversarial review pass went after the split-brain edge cases and changed the design. It led to the two-perspective fence instead of trusting a NotReady node on its own; the majority gate, so a minority failure is left to gossip and the Durable validity-factor refusal is never overruled; the Durable opt-in, because a forced takeover can drop acknowledged writes; validating `CLUSTER NODES` names against real pods, so a bare IP with no announce hostname can't look fenced; and clearing the debounce marker only on `cluster_state:ok`.

## Validation

- Unit tests cover the fence truth table, the majority gate including the even-N boundary, the debounce, the profile and annotation gating, and the pre-dial fence filter.
- Full envtest and lint are clean.
- Live on a dedicated k3d cluster (3 shards, 1 replica each, Cache): loaded 500 keys, cordoned every node, then force-deleted 2 of 3 primary pods so they stayed fenced while their replicas kept running. The operator armed the debounce, waited 45s, and took over both replicas. Result: `cluster_state:ok`, 16384 slots served, 500/500 keys intact. After uncordoning, the fenced primaries rescheduled and rejoined as replicas, and `status.quorumDownSince` cleared.

Closes the AR1 Cluster SPOF.
