### PR TITLE
Add a primary-only Service for Replication (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims to
 follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Replication clusters now get a `<cluster>-primary` Service that resolves to the
+  current primary only, giving write clients a stable endpoint. The cluster-wide
+  client Service (`<cluster>`) load-balances across the primary and its replicas,
+  so a client that must write would randomly land on a read-only replica. The
+  operator stamps a `valkey.wellcake.io/role` label (`primary`/`replica`) on the
+  data pods and moves it on failover, and the primary Service selects
+  `role=primary`. Fixes [#30](https://github.com/melancholictheory/wellcake/issues/30).
+
 ## [0.7.0]
 
 ### Added

--- a/charts/valkey-operator/templates/rbac.yaml
+++ b/charts/valkey-operator/templates/rbac.yaml
@@ -4,7 +4,7 @@
   (dict "apiGroups" (list "") "resources" (list "configmaps" "secrets" "services") "verbs" (list "create" "delete" "get" "list" "patch" "update" "watch"))
   (dict "apiGroups" (list "") "resources" (list "persistentvolumeclaims") "verbs" (list "get" "list" "patch" "update" "watch"))
   (dict "apiGroups" (list "") "resources" (list "events") "verbs" (list "create" "patch"))
-  (dict "apiGroups" (list "") "resources" (list "pods") "verbs" (list "delete" "get" "list" "watch"))
+  (dict "apiGroups" (list "") "resources" (list "pods") "verbs" (list "delete" "get" "list" "patch" "watch"))
   (dict "apiGroups" (list "apps") "resources" (list "statefulsets") "verbs" (list "create" "delete" "get" "list" "patch" "update" "watch"))
   (dict "apiGroups" (list "batch") "resources" (list "jobs") "verbs" (list "create" "delete" "get" "list" "patch" "update" "watch"))
   (dict "apiGroups" (list "batch") "resources" (list "cronjobs") "verbs" (list "create" "delete" "get" "list" "patch" "update" "watch"))

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -51,6 +51,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - apps

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -276,7 +276,13 @@ kubectl -n <ns> exec <cluster>-0 -- valkey-cli -a "$PW" --no-auth-warning \
 ## Connecting a client
 
 Service DNS:
-- `<cluster>.<ns>.svc.cluster.local:6379` (or `:6380` for TLS).
+- `<cluster>.<ns>.svc.cluster.local:6379` (or `:6380` for TLS). This cluster-wide
+  Service load-balances across the primary AND its replicas, so use it for reads
+  or cluster-aware clients, not for writes to a Replication primary.
+- `<cluster>-primary.<ns>.svc.cluster.local:6379` (Replication) resolves to the
+  current primary only and follows failover. Point write clients here. It is
+  backed by a `valkey.wellcake.io/role=primary` label the operator moves between
+  pods, so expect a brief gap during a failover while the label catches up.
 - For Sentinel, ask Sentinel first:
   `<cluster>-sentinel.<ns>.svc.cluster.local:26379`, command
   `SENTINEL get-master-addr-by-name mymaster`.

--- a/internal/controller/primary_service.go
+++ b/internal/controller/primary_service.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Wellcake Authors.
+*/
+
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	cachev1beta1 "github.com/melancholictheory/wellcake/api/v1beta1"
+)
+
+// ensurePrimaryService creates/updates the `<cluster>-primary` Service, a
+// ClusterIP that resolves only to the pod currently carrying roleLabel=primary.
+// It is static (the selector never changes); which pod it targets follows the
+// role label that ensureRoleLabels moves on failover.
+func (r *ValkeyClusterReconciler) ensurePrimaryService(ctx context.Context, vc *cachev1beta1.ValkeyCluster) error {
+	desired := buildPrimaryService(vc)
+	if err := controllerutil.SetControllerReference(vc, desired, r.Scheme); err != nil {
+		return err
+	}
+	return r.applyService(ctx, desired)
+}
+
+// ensureRoleLabels stamps the current primary pod with roleLabel=primary and
+// every other data pod with roleLabel=replica, so the primary Service resolves to
+// the right pod. It is called after failover has resolved the primary; `primary`
+// is the pod NAME (e.g. "<cluster>-0"). When it is empty (no primary known yet,
+// or a downstream replica cluster with spec.replicateFrom) the labels are left
+// untouched.
+//
+// The role label is not part of any StatefulSet selector, so this is a plain
+// label patch. A pod recreated by the StatefulSet comes back without the label
+// (it is not in the pod template), so the next reconcile re-stamps it; an
+// already-correct pod is skipped so this does not churn resourceVersion.
+func (r *ValkeyClusterReconciler) ensureRoleLabels(ctx context.Context, vc *cachev1beta1.ValkeyCluster, primary string) error {
+	if primary == "" {
+		return nil
+	}
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods,
+		client.InNamespace(vc.Namespace), client.MatchingLabels(labelsFor(vc))); err != nil {
+		return err
+	}
+	log := logf.FromContext(ctx)
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		want := roleReplica
+		if pod.Name == primary {
+			want = rolePrimary
+		}
+		if pod.Labels[roleLabel] == want {
+			continue // already correct — no write
+		}
+		patch := client.MergeFrom(pod.DeepCopy())
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
+		}
+		pod.Labels[roleLabel] = want
+		if err := r.Patch(ctx, pod, patch); err != nil {
+			// Best-effort: log and continue so one un-patchable pod does not block
+			// the others; the next reconcile retries.
+			log.Error(err, "role label patch failed", "pod", pod.Name, "role", want)
+		}
+	}
+	return nil
+}

--- a/internal/controller/primary_service_test.go
+++ b/internal/controller/primary_service_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The Wellcake Authors.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	cachev1beta1 "github.com/melancholictheory/wellcake/api/v1beta1"
+)
+
+func TestBuildPrimaryServiceSelectsPrimaryRole(t *testing.T) {
+	vc := &cachev1beta1.ValkeyCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "vk"},
+		Spec:       cachev1beta1.ValkeyClusterSpec{Topology: cachev1beta1.TopologyReplication},
+	}
+	svc := buildPrimaryService(vc)
+
+	if svc.Name != "vk-primary" {
+		t.Fatalf("name=%q, want vk-primary", svc.Name)
+	}
+	if svc.Spec.Selector[roleLabel] != rolePrimary {
+		t.Fatalf("selector must include %s=%s, got %v", roleLabel, rolePrimary, svc.Spec.Selector)
+	}
+	// Must still scope to this cluster, not just any primary.
+	if svc.Spec.Selector[instanceLabel] != "vk" {
+		t.Fatalf("selector must keep the instance scope, got %v", svc.Spec.Selector)
+	}
+	// The Service's own metadata labels must NOT carry the role selector.
+	if _, ok := svc.Labels[roleLabel]; ok {
+		t.Fatalf("service metadata labels must not include the role selector, got %v", svc.Labels)
+	}
+}
+
+// TestEnsureRoleLabels covers stamping, idempotency (no resourceVersion churn),
+// failover swap, and the empty-primary no-op.
+func TestEnsureRoleLabels(t *testing.T) {
+	scheme := newTestScheme(t)
+	vc := &cachev1beta1.ValkeyCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "vk"},
+		Spec:       cachev1beta1.ValkeyClusterSpec{Topology: cachev1beta1.TopologyReplication},
+	}
+	mkPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: name, Labels: labelsFor(vc)}}
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mkPod("vk-0"), mkPod("vk-1")).Build()
+	r := &ValkeyClusterReconciler{Client: c, Scheme: scheme}
+	ctx := context.Background()
+
+	get := func(name string) corev1.Pod {
+		var p corev1.Pod
+		if err := c.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, &p); err != nil {
+			t.Fatalf("get %s: %v", name, err)
+		}
+		return p
+	}
+
+	if err := r.ensureRoleLabels(ctx, vc, "vk-0"); err != nil {
+		t.Fatalf("ensureRoleLabels: %v", err)
+	}
+	if r0 := get("vk-0").Labels[roleLabel]; r0 != rolePrimary {
+		t.Fatalf("vk-0 role=%q, want primary", r0)
+	}
+	if r1 := get("vk-1").Labels[roleLabel]; r1 != roleReplica {
+		t.Fatalf("vk-1 role=%q, want replica", r1)
+	}
+
+	// Idempotent: a second identical call must not write (stable resourceVersion).
+	rv0, rv1 := get("vk-0").ResourceVersion, get("vk-1").ResourceVersion
+	if err := r.ensureRoleLabels(ctx, vc, "vk-0"); err != nil {
+		t.Fatalf("ensureRoleLabels (2): %v", err)
+	}
+	if get("vk-0").ResourceVersion != rv0 || get("vk-1").ResourceVersion != rv1 {
+		t.Fatal("second call churned resourceVersion — not idempotent")
+	}
+
+	// Failover: primary moves to vk-1, labels swap.
+	if err := r.ensureRoleLabels(ctx, vc, "vk-1"); err != nil {
+		t.Fatalf("ensureRoleLabels (3): %v", err)
+	}
+	if r0, r1 := get("vk-0").Labels[roleLabel], get("vk-1").Labels[roleLabel]; r0 != roleReplica || r1 != rolePrimary {
+		t.Fatalf("after failover vk-0=%s vk-1=%s, want replica/primary", r0, r1)
+	}
+
+	// Empty primary (unknown / downstream replica) is a no-op, not an error.
+	if err := r.ensureRoleLabels(ctx, vc, ""); err != nil {
+		t.Fatalf("ensureRoleLabels(empty): %v", err)
+	}
+}

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -70,6 +70,11 @@ const (
 	instanceLabel              = "app.kubernetes.io/instance"
 	partOfLabel                = "app.kubernetes.io/part-of"
 	managedByLabel             = "app.kubernetes.io/managed-by"
+	// roleLabel marks a data pod's current replication role so a Service can
+	// select just the primary (or just the replicas). The operator stamps it on
+	// every reconcile and moves it on failover; it is NOT part of any workload
+	// selector, so re-stamping is a plain label patch.
+	roleLabel = "valkey.wellcake.io/role"
 
 	// Shared literals used across job/pod/script builders.
 	shellCmd            = "/bin/sh"
@@ -105,6 +110,9 @@ const (
 	// Replication roles as reported by INFO replication / CLUSTER NODES.
 	roleMaster = "master"
 	roleSlave  = "slave"
+	// roleLabel values stamped on data pods (client-facing terminology).
+	rolePrimary = "primary"
+	roleReplica = "replica"
 	// topologyKeyHostname is the node-level failure domain for pod (anti-)affinity.
 	topologyKeyHostname = "kubernetes.io/hostname"
 	// Prometheus metric label names reused across collectors.
@@ -320,6 +328,39 @@ func buildClientService(vc *cachev1beta1.ValkeyCluster) *corev1.Service {
 			Type:     corev1.ServiceTypeClusterIP,
 			Selector: labelsFor(vc),
 			Ports:    ports,
+		},
+	}
+}
+
+func primaryServiceName(vc *cachev1beta1.ValkeyCluster) string { return vc.Name + "-primary" }
+
+// buildPrimaryService is a ClusterIP Service that resolves ONLY to the current
+// primary pod, by selecting the operator-managed role label. The cluster-wide
+// client Service (buildClientService) load-balances across the primary AND its
+// replicas, which breaks a Replication client that must write to the primary;
+// this gives such clients a stable write endpoint (`<cluster>-primary`).
+func buildPrimaryService(vc *cachev1beta1.ValkeyCluster) *corev1.Service {
+	port := valkeyPort
+	if tlsEnabled(vc) {
+		port = valkeyTLSPort
+	}
+	selector := labelsFor(vc)
+	selector[roleLabel] = rolePrimary
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      primaryServiceName(vc),
+			Namespace: vc.Namespace,
+			Labels:    labelsFor(vc),
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: selector,
+			Ports: []corev1.ServicePort{{
+				Name:       appValkey,
+				Port:       port,
+				TargetPort: intstr.FromInt32(port),
+				Protocol:   corev1.ProtocolTCP,
+			}},
 		},
 	}
 }

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -72,7 +72,7 @@ type ValkeyClusterReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services;configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;patch;delete
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
@@ -179,6 +179,13 @@ func (r *ValkeyClusterReconciler) reconcileReplication(ctx context.Context, vc *
 	if err := r.ensureClientService(ctx, vc); err != nil {
 		return ctrl.Result{}, fmt.Errorf("client service: %w", err)
 	}
+	// Primary-only Service: the client Service above load-balances across the
+	// primary and its replicas, so a write client needs a stable endpoint that
+	// resolves to just the primary. ensureRoleLabels (below) points it at the
+	// current primary and moves it on failover.
+	if err := r.ensurePrimaryService(ctx, vc); err != nil {
+		return ctrl.Result{}, fmt.Errorf("primary service: %w", err)
+	}
 	configHash, err := r.ensureConfigMap(ctx, vc, password)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("configmap: %w", err)
@@ -247,6 +254,12 @@ func (r *ValkeyClusterReconciler) reconcileReplication(ctx context.Context, vc *
 		// at the application layer; we requeue periodically so failover can
 		// notice a hung primary even if the pod is still Running.
 		requeueAfter = 15 * time.Second
+	}
+
+	// Point the primary Service at the current primary (and mark the rest as
+	// replicas). Best-effort: a failed patch is retried on the next reconcile.
+	if err := r.ensureRoleLabels(ctx, vc, primary); err != nil {
+		log.Error(err, "role labels")
 	}
 
 	res, err := r.updateStatus(ctx, vc, sts, primary)


### PR DESCRIPTION
Fixes #30.

The cluster-wide client Service (`<cluster>`) selects every pod, so for a Replication cluster it load-balances across the primary and its replicas. A client that needs to write ends up on a read-only replica at random, which is exactly what the reporter hit.

This adds a `<cluster>-primary` ClusterIP Service that resolves to the current primary only. The operator stamps a `valkey.wellcake.io/role` label (`primary` or `replica`) on the data pods and moves it on failover; the primary Service selects `role=primary`. The label lives outside the StatefulSet pod template, so the operator re-stamps it every reconcile and skips pods that are already correct, which keeps it from churning resourceVersion. It needs the `pods:patch` RBAC verb, added here in both the config and the chart.

Scope is Replication, where the operator already tracks the primary. Standalone has a single pod the client Service already points to, Cluster has many primaries, and Sentinel exposes its own discovery through Sentinel.

### Validation

- Unit tests: the primary Service selects `role=primary` and stays scoped to the cluster; the labeler stamps primary and replica, is idempotent, and swaps on failover.
- Full envtest and lint clean.
- Live on k3d: a 3-pod Replication cluster. `repltest-primary` resolved to only the primary pod, while the cluster-wide Service still had all three. A manual failover moved the primary to another pod, and the Service endpoints and role labels followed.
