### PR TITLE
Add a replica-only read Service for Replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims to
 follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Replication clusters also get a `<cluster>-replicas` Service that load-balances
+  across the replica pods only, for spreading reads. It completes the read/write
+  split started in 0.7.1: `<cluster>-primary` for writes, `<cluster>-replicas` for
+  reads, and the cluster-wide `<cluster>` Service across all pods. It reuses the
+  same `valkey.wellcake.io/role` label the operator already maintains, so a pod
+  demoted on failover starts serving reads through it automatically.
+
 ## [0.7.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ aims to:
   `Durable` (noeviction, RDB+AOF, 10Gi PVC)
 - **Operator-driven failover** for Replication: TCP survey every 15s, promote the
   replica with the max offset, split-brain protection after a pod-0 restart
-- **Primary Service** for Replication: a `<cluster>-primary` Service resolving to
-  the current primary only (via a `valkey.wellcake.io/role` pod label the operator
-  moves on failover), so write clients get a stable endpoint separate from the
-  load-balanced cluster-wide Service
+- **Split read/write Services** for Replication: a `<cluster>-primary` Service
+  resolving to the current primary only (for writes) and a `<cluster>-replicas`
+  Service across the replicas only (for reads), driven by a
+  `valkey.wellcake.io/role` pod label the operator moves on failover — separate
+  from the load-balanced cluster-wide `<cluster>` Service
 - **Proactive rolling restart** (ADR 0004, opt-in via annotation
   `valkey.wellcake.io/proactive-rollout: "true"`, default OFF) for Replication /
   Cluster / Sentinel: the StatefulSet switches to `OnDelete`, the operator rolls

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,9 +33,9 @@ consciously accepted **before durable production**.
 
 | # | Risk | Severity | Substance and direction |
 |---|---|---|---|
-| AR1 | Operator is the sole failover arbiter for Replication | high (warning ✅) | `surveyReplication`/promotion runs via requeue every 15s and **only while the operator is alive**. RTO = up to 15s + reconcile; with the operator down there is no failover. For durable workloads this is weaker than data-plane arbitration. **Done:** admission warning on durable+Replication (a soft nudge toward Sentinel/Cluster). **Investigated (cha-04 → diagnostic run, operator log dump): no gap.** The operator **detects a hung primary as unreachable and promotes a replica** (log `promoting replica`). The initial "no failover" was an artifact: the liveness probe **restarts** the hung container within ~8s (DEBUG SLEEP → liveness-fail → restart), so the "hang" turns into a "restart of an empty pod" (handled by the empty-master guard), and with equal/zero data the operator re-adopts the original ordinal. Side note: the diagnostic exposed an **STS conflict churn** (`ensureStatefulSet` failed on "object has been modified" → the whole reconcile errored before the failover step) → **fixed** (RetryOnConflict, see CHANGELOG) — removes promotion delay under racing reconciles. Optional remainder: a hard gate / default durable→Sentinel. Related to EC1. |
+| AR1 | Operator is the sole failover arbiter for Replication | high (warning ✅) | `surveyReplication`/promotion runs via requeue every 15s and **only while the operator is alive**. RTO = up to 15s + reconcile; with the operator down there is no failover. For durable workloads this is weaker than data-plane arbitration. **Done:** admission warning on durable+Replication (a soft nudge toward Sentinel/Cluster). **Investigated (cha-04 → diagnostic run, operator log dump): no gap.** The operator **detects a hung primary as unreachable and promotes a replica** (log `promoting replica`). The initial "no failover" was an artifact: the liveness probe **restarts** the hung container within ~8s (DEBUG SLEEP → liveness-fail → restart), so the "hang" turns into a "restart of an empty pod" (handled by the empty-master guard), and with equal/zero data the operator re-adopts the original ordinal. Side note: the diagnostic exposed an **STS conflict churn** (`ensureStatefulSet` failed on "object has been modified" → the whole reconcile errored before the failover step) → **fixed** (RetryOnConflict, see CHANGELOG) — removes promotion delay under racing reconciles. **Hard gate: done** — the webhook rejects durable+Replication unless `valkey.wellcake.io/accept-replication-durability-risk` is set. The analogous **Cluster** gap (a lost primary majority, which gossip cannot vote a failover through) is closed by **quorum recovery** (ADR 0006): operator-driven `CLUSTER FAILOVER TAKEOVER` after a two-sided fence — automatic for Cache, opt-in for Durable. Related to EC1. |
 | AR2 | Bootstrap idempotency tied to a status flag | **done** | Before `--cluster create` the operator checks the actual `CLUSTER INFO` (pod-0): an already-formed cluster is adopted (`AdoptedExisting`) instead of being re-initialized. Closes the footgun of a lost status flag. |
-| AR3 | Backup/restore asymmetry | high (mostly closed) | Backup is mature (per-shard fanout, retention, SSE, ~~verify~~ ✅ B1). Restore: single-shard ✅, Cluster — ~~per-shard restore-init + bootstrap-safety + adopt + slot manifest in the backup~~ ✅ (C2 incrementally), the remaining gap is **automatic cluster assembly** (ADDSLOTSRANGE/MEET/REPLICATE from the manifest) — currently manual via runbook. |
+| AR3 | Backup/restore asymmetry | high (mostly closed) | Backup is mature (per-shard fanout, retention, SSE, ~~verify~~ ✅ B1). Restore: single-shard ✅, Cluster — ~~per-shard restore-init + bootstrap-safety + adopt + slot manifest in the backup~~ ✅ (C2 incrementally), **automatic cluster assembly** (ADDSLOTSRANGE/MEET/REPLICATE from the manifest) is **done** via the C2 assembly Job. |
 | AR4 | Defaulting in reconcile + no conversion webhook (✅ both addressed) | low | ~~`applyDefaults` in reconcile~~ ✅ E2 (mutating webhook). ~~No API versioning~~ ✅ E1 groundwork — v1beta1 Hub/storage + v1alpha1 spoke + conversion + multiversion CRD; the safe-evolution window is open (remaining: activate `conversion: Webhook` when schemas diverge). |
 | AR5 | Secret rotation requires a manual restart | **done** | The config hash deliberately excludes secrets → a password/TLS change did not roll the pods. ~~Password~~ ✅ S3: in-place rotation without restart via the `valkey.wellcake.io/rotate-password` annotation (live ACL SETUSER on the default user + masterauth, no replication blip). ~~TLS~~ ✅: automatic cert reload on cert-manager renewal (watch on the TLS Secret → live `CONFIG SET tls-cert-file/key/ca`, verified through the TLS handshake itself to bypass the kubelet sync delay, no restart). Verified on a local kind/k3d cluster (Replication+TLS). ~~Remaining: operator dial-ins under mTLS~~ ✅: `dialReplClient` now presents a client cert (`loadMTLSClientCert`) → failover/survey/password rotation work under `tls.mutualTLS` (verified locally: survey→primary, failover kv-0→kv-1). |
 
@@ -92,8 +92,8 @@ immutability is best-in-class (Q6).
 
 | # | What | Priority |
 |---|---|---|
-| S1 | ACL for Sentinel | **mostly done** — Sentinel talks to the master through a dedicated `sentinel-user` (no key access) via `sentinel auth-user`, not as default+requirepass. Remaining: narrow to a minimal per-command set (needs e2e failover validation on a cluster); ACL for the client-to-sentinel/inter-sentinel port — optional |
-| S2 | Pod Security Standards labels on the namespace (`pod-security.kubernetes.io/enforce: restricted`) — add to the Helm chart | low |
+| S1 | ACL for Sentinel | **mostly done** — Sentinel talks to the master through a dedicated `sentinel-user` (no key access) via `sentinel auth-user`, not as default+requirepass. The minimal per-command set is **done** (`sentinelACLCommands`, seeded in `users.acl`). Only optional remains: an ACL on the client-to-sentinel/inter-sentinel port. |
+| S2 | Pod Security Standards labels on the namespace (`pod-security.kubernetes.io/enforce: restricted`) | **done** — the `valkey-cluster` chart can create + label the namespace (`namespace.create`, `namespace.podSecurityStandard`), 0.3.0 |
 | S3 | Password rotation without restart | **done** — operator-initiated in-place rotation via the `valkey.wellcake.io/rotate-password=<token>` annotation (operator-managed Secret). The operator knows the old password from the current Secret → rolls the new one to live pods without restart: an additive pass (the default user accepts old+new, replicas switch masterauth → **no replication blip**), then cutover (drop the old, `ACL SAVE` to users.acl → restart-safe). Once-per-token via an uncached APIReader guard. Verified on a local kind/k3d cluster (3-node Replication: live rotation, 0 restarts, `sync_full` did not grow, restart-safe). ExistingSecret is out of scope (the operator doesn't know the old password). |
 | S4 | Multi-region mTLS with an explicit CA mount | **done** — `replicateFrom.caSecret` (S4): the operator mounts the source cluster's CA itself and merges it with the local CA into a single trust bundle (`/data/ca-bundle.crt`), since Valkey reads one global `tls-ca-cert-file`. The bundle is built in `config-init`, and `tls-reload` points at it too (so renewing the local cert doesn't drop trust in the source CA). Previously the user mounted the source cluster's CA bundle by hand. CEL+webhook require `replicateFrom.tls=true`+`tls.enabled=true`. |
 
@@ -132,7 +132,7 @@ immutability is best-in-class (Q6).
 
 | # | What | Priority |
 |---|---|---|
-| EC1 | Split-brain in Replication between two network partitions: enforceReplication closes the window after a pod-0 restart but is not protected against a network split — needs Sentinel | warning ✅ (AR1) — durable+Replication gives an admission warning; a hard gate is optional |
+| EC1 | Split-brain in Replication between two network partitions: enforceReplication closes the window after a pod-0 restart but is not protected against a network split — needs Sentinel | **gated ✅** (AR1) — the webhook rejects durable+Replication unless `valkey.wellcake.io/accept-replication-durability-risk` is set |
 | EC2 | Scale-down + multi-region combination is untested (should work, but edge cases are possible) | low |
 | EC3 | Active-active / bidirectional replication between ValkeyClusters — impossible in OSS Valkey (only Redis Enterprise) | out of scope |
 
@@ -155,15 +155,20 @@ durable production than the remaining quality/ops tasks.
 5. ~~**T7 envtest in CI**~~ ✅ (infra ready: assets + job).
 6. ~~**S1 Sentinel ACL**~~ ✅ ~~**Op2/Op3 procedures**~~ ✅ — closed.
 
-The priority roadmap backlog is exhausted. Also closed are the design-review
+The priority roadmap backlog is exhausted. **Post-backlog work shipped in 0.7.x:**
+Cluster majority-loss recovery (ADR 0006 — operator quorum takeover after a
+two-sided fence), split read/write Services for Replication (`<cluster>-primary`
+for writes, `<cluster>-replicas` for reads, driven by a role label), and a
+dedicated least-privilege replication ACL user. Also closed are the design-review
 items: STS Parallel + PVC expansion (confirmed bugs), ADR 0002
 (workload primitive), 0003 (build-vs-adopt), 0004 (proactive failover — design +
 implementation: operator-driven rolling restart for Replication/Cluster/Sentinel,
 opt-in via the `valkey.wellcake.io/proactive-rollout` annotation, default OFF),
-0001 (C3/ASM — implemented), 0005 (C1 per-shard workload — implemented),
+0001 (C3/ASM — implemented), 0005 (C1 per-shard workload — implemented), 0006
+(quorum recovery — implemented),
 CODEOWNERS/CONTRIBUTING/prod-readiness/compat-matrix. Residual follow-ups (as
-needed, all requiring live/e2e): a hard gate for AR1, activating
-`conversion: Webhook` (E1), a minimal per-command Sentinel ACL (S1),
+needed, all requiring live/e2e): activating
+`conversion: Webhook` (E1), the optional Sentinel-port ACL (S1),
 **chaos/integration tests** (plan — [docs/chaos-testing.md](docs/chaos-testing.md);
 Layer 1 pod-kill scenarios → Layer 2 under Chaos Mesh) + bus factor + flipping
 the proactive-rollout default after a soak. Low-priority S2/I2/EC2 — on request
@@ -175,11 +180,12 @@ selector — a regression from the failover fix, prioritized), **SC2**
 (`MaxConcurrentReconciles` > 1), **SC4** (immutability on `spec.storage.mode`);
 SC3 (ops guide for 500+) and SC5 (CEL cleanliness) — low priority.
 
-All priority AR problems from the critical review are addressed: AR1 (warning),
+All priority AR problems from the critical review are addressed: AR1 (gated — the
+webhook rejects durable+Replication, plus Cluster quorum recovery),
 AR2 (partially via restore safety), AR3 (B1 + C2 reassembly), AR4 (E2 mutating
-webhook + E1 v1beta1 groundwork). Residual follow-ups: a hard gate for AR1
-(optional), activating `conversion: Webhook` in the CRD/chart (E1, at the first
-v1alpha1/v1beta1 schema divergence).
+webhook + E1 v1beta1 groundwork). Residual follow-ups: activating
+`conversion: Webhook` in the CRD/chart (E1, at the first v1alpha1/v1beta1 schema
+divergence).
 
 Done: T1 (envtest suite), T2 (kuttl advanced e2e: fal/shd/scl/bkp), T3 (mostly —
 unit+RESP mock+envtest finalizer), T4 (webhook tests), T5 (CI lint gate), T6

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -283,6 +283,9 @@ Service DNS:
   current primary only and follows failover. Point write clients here. It is
   backed by a `valkey.wellcake.io/role=primary` label the operator moves between
   pods, so expect a brief gap during a failover while the label catches up.
+- `<cluster>-replicas.<ns>.svc.cluster.local:6379` (Replication) load-balances
+  across the replicas only. Point read-only clients here to spread reads; it is
+  empty on a single-node cluster.
 - For Sentinel, ask Sentinel first:
   `<cluster>-sentinel.<ns>.svc.cluster.local:26379`, command
   `SENTINEL get-master-addr-by-name mymaster`.

--- a/docs/topologies.md
+++ b/docs/topologies.md
@@ -61,11 +61,14 @@ quorum-based failover, use **Sentinel** below.
 
 Services:
 - `<name>` — client Service across **every** pod (primary + replicas). Use it for
-  reads or for clients that don't care which pod they reach.
+  clients that don't care which pod they reach.
 - `<name>-primary` — resolves to the **current primary only** and follows
   failover, backed by a `valkey.wellcake.io/role=primary` pod label the operator
   moves. Point write clients here. There is a brief gap during a failover while
   the label catches up.
+- `<name>-replicas` — load-balances across the **replicas only**
+  (`role=replica`), for spreading reads. Empty of endpoints on a single-node
+  cluster; a pod demoted on failover starts serving reads through it.
 - `<name>-headless` — headless Service for the Valkey pods.
 
 ## Sentinel

--- a/internal/controller/primary_service.go
+++ b/internal/controller/primary_service.go
@@ -27,6 +27,19 @@ func (r *ValkeyClusterReconciler) ensurePrimaryService(ctx context.Context, vc *
 	return r.applyService(ctx, desired)
 }
 
+// ensureReplicasService creates/updates the `<cluster>-replicas` Service, a
+// ClusterIP that load-balances across the replica pods only (roleLabel=replica),
+// for spreading reads. It has no endpoints until at least one replica is
+// labelled; on a single-node or all-down cluster it is simply empty, which is
+// correct.
+func (r *ValkeyClusterReconciler) ensureReplicasService(ctx context.Context, vc *cachev1beta1.ValkeyCluster) error {
+	desired := buildReplicasService(vc)
+	if err := controllerutil.SetControllerReference(vc, desired, r.Scheme); err != nil {
+		return err
+	}
+	return r.applyService(ctx, desired)
+}
+
 // ensureRoleLabels stamps the current primary pod with roleLabel=primary and
 // every other data pod with roleLabel=replica, so the primary Service resolves to
 // the right pod. It is called after failover has resolved the primary; `primary`

--- a/internal/controller/primary_service_test.go
+++ b/internal/controller/primary_service_test.go
@@ -39,6 +39,27 @@ func TestBuildPrimaryServiceSelectsPrimaryRole(t *testing.T) {
 	}
 }
 
+func TestBuildReplicasServiceSelectsReplicaRole(t *testing.T) {
+	vc := &cachev1beta1.ValkeyCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "vk"},
+		Spec:       cachev1beta1.ValkeyClusterSpec{Topology: cachev1beta1.TopologyReplication},
+	}
+	svc := buildReplicasService(vc)
+
+	if svc.Name != "vk-replicas" {
+		t.Fatalf("name=%q, want vk-replicas", svc.Name)
+	}
+	if svc.Spec.Selector[roleLabel] != roleReplica {
+		t.Fatalf("selector must include %s=%s, got %v", roleLabel, roleReplica, svc.Spec.Selector)
+	}
+	if svc.Spec.Selector[instanceLabel] != "vk" {
+		t.Fatalf("selector must keep the instance scope, got %v", svc.Spec.Selector)
+	}
+	if _, ok := svc.Labels[roleLabel]; ok {
+		t.Fatalf("service metadata labels must not include the role selector, got %v", svc.Labels)
+	}
+}
+
 // TestEnsureRoleLabels covers stamping, idempotency (no resourceVersion churn),
 // failover swap, and the empty-primary no-op.
 func TestEnsureRoleLabels(t *testing.T) {

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -332,23 +332,25 @@ func buildClientService(vc *cachev1beta1.ValkeyCluster) *corev1.Service {
 	}
 }
 
-func primaryServiceName(vc *cachev1beta1.ValkeyCluster) string { return vc.Name + "-primary" }
+func primaryServiceName(vc *cachev1beta1.ValkeyCluster) string  { return vc.Name + "-primary" }
+func replicasServiceName(vc *cachev1beta1.ValkeyCluster) string { return vc.Name + "-replicas" }
 
-// buildPrimaryService is a ClusterIP Service that resolves ONLY to the current
-// primary pod, by selecting the operator-managed role label. The cluster-wide
-// client Service (buildClientService) load-balances across the primary AND its
-// replicas, which breaks a Replication client that must write to the primary;
-// this gives such clients a stable write endpoint (`<cluster>-primary`).
-func buildPrimaryService(vc *cachev1beta1.ValkeyCluster) *corev1.Service {
+// buildRoleService is a ClusterIP Service that resolves to the data pods carrying
+// a given role label (primary or replica). It backs the split endpoints for
+// Replication: the cluster-wide client Service load-balances across EVERY pod,
+// which is wrong both for a client that must reach the primary (writes) and for
+// one that wants to spread reads across replicas only. `<cluster>-primary`
+// selects the primary; `<cluster>-replicas` selects the replicas.
+func buildRoleService(vc *cachev1beta1.ValkeyCluster, name, role string) *corev1.Service {
 	port := valkeyPort
 	if tlsEnabled(vc) {
 		port = valkeyTLSPort
 	}
 	selector := labelsFor(vc)
-	selector[roleLabel] = rolePrimary
+	selector[roleLabel] = role
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      primaryServiceName(vc),
+			Name:      name,
 			Namespace: vc.Namespace,
 			Labels:    labelsFor(vc),
 		},
@@ -363,6 +365,14 @@ func buildPrimaryService(vc *cachev1beta1.ValkeyCluster) *corev1.Service {
 			}},
 		},
 	}
+}
+
+func buildPrimaryService(vc *cachev1beta1.ValkeyCluster) *corev1.Service {
+	return buildRoleService(vc, primaryServiceName(vc), rolePrimary)
+}
+
+func buildReplicasService(vc *cachev1beta1.ValkeyCluster) *corev1.Service {
+	return buildRoleService(vc, replicasServiceName(vc), roleReplica)
 }
 
 func buildConfigMap(vc *cachev1beta1.ValkeyCluster, password string) *corev1.ConfigMap {

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -186,6 +186,11 @@ func (r *ValkeyClusterReconciler) reconcileReplication(ctx context.Context, vc *
 	if err := r.ensurePrimaryService(ctx, vc); err != nil {
 		return ctrl.Result{}, fmt.Errorf("primary service: %w", err)
 	}
+	// Replica-only Service (`<cluster>-replicas`) for spreading reads across the
+	// replicas; empty of endpoints until a replica is labelled.
+	if err := r.ensureReplicasService(ctx, vc); err != nil {
+		return ctrl.Result{}, fmt.Errorf("replicas service: %w", err)
+	}
 	configHash, err := r.ensureConfigMap(ctx, vc, password)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("configmap: %w", err)


### PR DESCRIPTION
Completes the read/write split for Replication started in 0.7.1.

0.7.1 (#30) added `<cluster>-primary` for writes. This adds `<cluster>-replicas`, a ClusterIP that load-balances across the replica pods only, so read traffic can be spread across replicas separately from the cluster-wide Service (all pods) and the primary Service (writes). It reuses the `valkey.wellcake.io/role` label the operator already maintains (extracted into a shared `buildRoleService`), so a pod demoted on failover starts serving reads through it on its own. No new RBAC.

This is the read Service I offered in #30.

The PR also refreshes the ROADMAP. It records the 0.7.x work (Cluster quorum recovery, split read/write Services, dedicated replication user) and corrects several statuses that were stale (already done in code but still listed as open): the AR1 hard gate (the webhook already rejects durable+Replication), the S1 minimal Sentinel command set, AR3 automatic cluster assembly (C2), and S2 namespace PSS labels (0.3.0).

### Validation

- Unit test: the replicas Service selects `role=replica` and stays scoped to the cluster.
- Full envtest and lint clean.
- Live on k3d: a 3-pod Replication cluster. `<cluster>-replicas` resolved to the two replicas only, `<cluster>-primary` to the primary only, and the cluster-wide Service to all three.
